### PR TITLE
Sort results topoligically from load.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5781,9 +5781,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-4.1.1.tgz",
-      "integrity": "sha512-vUTjC26K73zZC9BB1vYD4Zsb7vqYLRujcTw3/qc74gmXOyAlc4QZz4sfHhJaqKlk2rteDKudHHB95ug7HhR2qQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-4.1.2.tgz",
+      "integrity": "sha512-9aHAwWRPFgjB3PwzdOmGBW8yeTkwsn0f8VE+JgA66pA2sgSiR+g2Mtlt0dIlmgUy/WaCjTpmc0EJtXFHdKgERg==",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
         "@stablelib/sha512": "^1.0.1",
@@ -11586,9 +11586,9 @@
       }
     },
     "jinaga": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-4.1.1.tgz",
-      "integrity": "sha512-vUTjC26K73zZC9BB1vYD4Zsb7vqYLRujcTw3/qc74gmXOyAlc4QZz4sfHhJaqKlk2rteDKudHHB95ug7HhR2qQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-4.1.2.tgz",
+      "integrity": "sha512-9aHAwWRPFgjB3PwzdOmGBW8yeTkwsn0f8VE+JgA66pA2sgSiR+g2Mtlt0dIlmgUy/WaCjTpmc0EJtXFHdKgERg==",
       "requires": {
         "@stablelib/base64": "^1.0.1",
         "@stablelib/sha512": "^1.0.1",


### PR DESCRIPTION
Allows consumers to interpret results directly no matter how deep.