### PR TITLE
Treat unknown types in given as unsatisfiable specifications

### DIFF
--- a/replicator/index.ts
+++ b/replicator/index.ts
@@ -18,7 +18,7 @@ app.use(express.text());
 app.use(cors());
 
 const pgConnection = process.env.JINAGA_POSTGRESQL ||
-  'postgresql://raasuser:raaspw@localhost:5432/raas';
+  'postgresql://appuser:apppw@localhost:5432/appdb';
 const { handler } = JinagaServer.create({
   pgStore: pgConnection
 });

--- a/replicator/tsconfig.json
+++ b/replicator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
       "target": "es6",
+      "lib": [ "ES2019" ],
       "module": "commonjs",
       "sourceMap": true,
       "baseUrl": "./dist",

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -64,7 +64,7 @@ function getOrStream<U>(
                             })
                             .done(() => {
                                 clearTimeout(timeout);
-                                res.socket.end();
+                                res.socket?.end();
                             });
                     }
                 })

--- a/src/postgres/query-description.ts
+++ b/src/postgres/query-description.ts
@@ -1,5 +1,5 @@
 import { FactReference, Label, Match, PathCondition } from "jinaga";
-import { FactTypeMap, RoleMap, ensureGetFactTypeId, getFactTypeId, getRoleId } from "./maps";
+import { FactTypeMap, RoleMap, getFactTypeId, getRoleId } from "./maps";
 
 export interface FactDescription {
     type: string;
@@ -323,9 +323,13 @@ export class QueryDescriptionBuider {
             if (givenIndex < 0) {
                 throw new Error(`No input parameter found for label ${condition.labelRight}`);
             }
+            const factTypeId = getFactTypeId(this.factTypes, start[givenIndex].type);
+            if (!factTypeId) {
+                return { queryDescription: QueryDescription.unsatisfiable, knownFacts };
+            }
             const { queryDescription: newQueryDescription, factDescription } = queryDescription.withInputParameter(
                 given[givenIndex],
-                ensureGetFactTypeId(this.factTypes, start[givenIndex].type),
+                factTypeId,
                 start[givenIndex].hash,
                 path
             );


### PR DESCRIPTION
- Return unsatisfiable specification if given type is not known
- Use es2019 for replicator
- Socket might be null
- Use the documented username and password for the Postgres database
