### PR TITLE
Retry on duplicate key violation

### DIFF
--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -18,9 +18,7 @@ export class ConnectionFactory {
                     return result;
                 }
                 catch (e) {
-                    Trace.warn("Postgres transaction error: " + describeError(e));
                     await connection.query('ROLLBACK');
-                    Trace.error(e);
                     throw e;
                 }
             }
@@ -49,6 +47,7 @@ export class ConnectionFactory {
                 Trace.warn("Postgres transient error: " + describeError(e));
                 attempt++;
                 if (attempt === maxAttempts) {
+                    Trace.error("Postgres error after max attempts: " + describeError(e));
                     throw e;
                 }
             }

--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -10,17 +10,15 @@ export class ConnectionFactory {
 
     withTransaction<T>(callback: (connection: PoolClient) => Promise<T>) {
         return this.with(async connection => {
-            while (true) {
-                try {
-                    await connection.query('BEGIN');
-                    const result = await callback(connection);
-                    await connection.query('COMMIT');
-                    return result;
-                }
-                catch (e) {
-                    await connection.query('ROLLBACK');
-                    throw e;
-                }
+            try {
+                await connection.query('BEGIN');
+                const result = await callback(connection);
+                await connection.query('COMMIT');
+                return result;
+            }
+            catch (e) {
+                await connection.query('ROLLBACK');
+                throw e;
             }
         });
     }

--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -51,8 +51,8 @@ export class ConnectionFactory {
                     throw e;
                 }
             }
-            const delayTime = baseDelay * Math.pow(2, attempt);
-            Trace.warn("Postgres retrying in " + delayTime + "ms");
+            const delayTime = baseDelay * Math.pow(2, attempt-1);
+            Trace.warn("Attempt number " + attempt + ". Postgres retrying in " + delayTime + "ms");
             await delay(delayTime);
         }
         throw new Error("Number of attempts exceeded");


### PR DESCRIPTION
Streamline the retry mechanism for Postgres transactions, enhance error handling, and eliminate redundant logging for duplicate key errors and transient issues.