### PR TITLE
Support graph protocol in the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "jinaga": "^6.6.2",
+        "jinaga": "^6.7.0",
         "pg": "^8.13.1"
       },
       "devDependencies": {
@@ -3948,9 +3948,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.6.2.tgz",
-      "integrity": "sha512-CuSt41b3NZYx0hU0F6Sj6HqmPBLZTHZrHG4eYtQ3OD9Pp3qoJwGljqXIL9oWlWMwi2hZUNVVP5aqXnLSttMPLg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.7.0.tgz",
+      "integrity": "sha512-PudjsHgqEpvBS7onK+6bN6+zyC+e4QPXMTIIDi/TrlrpISeWBckKzFCqj0v73oUHh9jXx2d0/oY1tkiovWA1BA==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "jinaga": "^6.6.2",
+    "jinaga": "^6.7.0",
     "pg": "^8.13.1"
   }
 }

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -555,11 +555,12 @@ export class HttpRouter {
     }
 
     private setOptions(router: Router, path: string): OptionsConfiguration {
-        const addOptions = (allowedMethods: string[], allowedHeaders: string[], allowedTypes: string[]) => {
+        const addOptions = (allowedMethods: string[], allowedHeaders: string[], exposedHeaders: string[], allowedTypes: string[]) => {
             router.options(path, this.applyAllowOrigin.bind(this), (req: Request, res: Response) => {
                 res.set('Allow', allowedMethods.join(', '));
                 res.set('Access-Control-Allow-Methods', allowedMethods.join(', '));
                 res.set('Access-Control-Allow-Headers', allowedHeaders.join(', '));
+                res.set('Access-Control-Expose-Headers', exposedHeaders.join(', '));
                 if (allowedTypes.length > 0) {
                     res.set('Accept-Post', allowedTypes.join(', '));
                 }
@@ -569,7 +570,7 @@ export class HttpRouter {
 
         return {
             intendedForGet: () => {
-                addOptions(['GET', 'OPTIONS'], ['Accept', 'Authorization'], []);
+                addOptions(['GET', 'OPTIONS'], ['Accept', 'Authorization'], [], []);
                 return {
                     returningContent: () => { },
                     returningNoContent: () => { }
@@ -581,12 +582,14 @@ export class HttpRouter {
                         addOptions(
                             ['POST', 'OPTIONS'],
                             ['Content-Type', 'Accept', 'Authorization'],
+                            ['Accept-Post'],
                             contentTypes);
                     },
                     returningNoContent: () => {
                         addOptions(
                             ['POST', 'OPTIONS'],
                             ['Content-Type', 'Authorization'],
+                            ['Accept-Post'],
                             contentTypes);
                     }
                 };


### PR DESCRIPTION
Introduce a queue processing delay in the persistent fork initialization and update the Jinaga dependency to version 6.7.0. Additionally, set the Access-Control-Expose-Headers response header for improved CORS handling.