### PR TITLE
Bump jinaga to 6.8.0 and handle late-arriving authorizing fact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "csv-stringify": "^6.6.0",
         "express": "^4.21.2",
-        "jinaga": "^6.7.26",
+        "jinaga": "^6.8.0",
         "pg": "^8.13.1"
       },
       "devDependencies": {
@@ -3955,9 +3955,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.7.26",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.7.26.tgz",
-      "integrity": "sha512-qXILUA1faeFWTYZnpbG8ZCpbndz5MF2yOgxiGUzW5oh9Xrr9xAUFJPiKzJc3I81STYhhD/MLiTNIOVIs7oaCiw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.8.0.tgz",
+      "integrity": "sha512-YN2CtA3PcIDpLR/2fQQTSX5IeoxynEVXLtvHWfK2bUpDrPzfDjsxc8ALbN7OZlEVMeOZuxvtQdgHYH79qqe0iQ==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "csv-stringify": "^6.6.0",
     "express": "^4.21.2",
-    "jinaga": "^6.7.26",
+    "jinaga": "^6.8.0",
     "pg": "^8.13.1"
   }
 }

--- a/src/authorization/authorization-keystore.ts
+++ b/src/authorization/authorization-keystore.ts
@@ -22,10 +22,24 @@ export interface DistributionIntersectionBranch {
     specification: Specification;
 }
 
+export interface SubscriptionAuthorizer {
+    verifyDistributionOrIntersect(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        namedStart: ReferencesByName
+    ): Promise<DistributionIntersectionBranch[]>;
+    feedPreVerified(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        start: FactReference[],
+        bookmark: string
+    ): Promise<FactFeed>;
+}
+
 import { Keystore } from "../keystore";
 import { DistributedFactCache } from "./distributed-fact-cache";
 
-export class AuthorizationKeystore implements Authorization {
+export class AuthorizationKeystore implements Authorization, SubscriptionAuthorizer {
     private authorizationEngine: AuthorizationEngine | null;
     private distributionEngine: DistributionEngine | null;
     private distributedFacts: DistributedFactCache = new DistributedFactCache();

--- a/src/authorization/authorization-keystore.ts
+++ b/src/authorization/authorization-keystore.ts
@@ -17,6 +17,11 @@ import {
     factReferenceEquals
 } from "jinaga";
 
+export interface DistributionIntersectionBranch {
+    start: FactReference[];
+    specification: Specification;
+}
+
 import { Keystore } from "../keystore";
 import { DistributedFactCache } from "./distributed-fact-cache";
 
@@ -94,6 +99,25 @@ export class AuthorizationKeystore implements Authorization {
         }
     }
 
+    async feedPreVerified(userIdentity: UserIdentity | null, specification: Specification, start: FactReference[], bookmark: string): Promise<FactFeed> {
+        // Caller has already established that this feed is safe to serve
+        // (e.g. produced by intersectForSubscribe — the spec lifts its own
+        // authorization condition into the matches and therefore self-
+        // filters). Skip the redundant per-query distribution check, but
+        // keep tracking the returned references so /load stays consistent.
+        const factFeed = await this.store.feed(specification, start, bookmark);
+        if (this.distributionEngine) {
+            const userReference: FactReference | null = userIdentity
+                ? await this.keystore.getUserFact(userIdentity)
+                : null;
+            const factReferences = factFeed.tuples
+                .flatMap(tuple => tuple.facts)
+                .filter((value, index, self) => self.findIndex(factReferenceEquals(value)) === index);
+            this.distributedFacts.add(factReferences, userReference);
+        }
+        return factFeed;
+    }
+
     async load(userIdentity: UserIdentity, references: FactReference[]) {
         if (this.distributionEngine) {
             const userFact = userIdentity ? await this.keystore.getUserFact(userIdentity) : null;
@@ -164,5 +188,29 @@ export class AuthorizationKeystore implements Authorization {
         if (canDistribute.type === "failure") {
             throw new Forbidden(canDistribute.reason);
         }
+    }
+
+    async verifyDistributionOrIntersect(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        namedStart: ReferencesByName
+    ): Promise<DistributionIntersectionBranch[]> {
+        const start = specification.given.map(g => namedStart[g.label.name]);
+        if (!this.distributionEngine) {
+            return [{ start, specification }];
+        }
+        const userReference: FactReference | null = userIdentity
+            ? await this.keystore.getUserFact(userIdentity)
+            : null;
+        const targetFeeds = buildFeeds(specification);
+        const canDistribute = await this.distributionEngine.canDistributeToAll(targetFeeds, namedStart, userReference);
+        if (canDistribute.type === "success") {
+            return [{ start, specification }];
+        }
+        const result = await this.distributionEngine.intersectForSubscribe(start, specification, userReference);
+        if (!result.intersected) {
+            throw new Forbidden(canDistribute.reason);
+        }
+        return result.branches;
     }
 }

--- a/src/authorization/authorization-keystore.ts
+++ b/src/authorization/authorization-keystore.ts
@@ -22,18 +22,32 @@ export interface DistributionIntersectionBranch {
     specification: Specification;
 }
 
+export type DistributionBranchesResult =
+    | { type: "success"; branches: DistributionIntersectionBranch[] }
+    | { type: "denied"; reason: string };
+
+export type FeedResult =
+    | { type: "success"; feed: FactFeed }
+    | { type: "denied"; reason: string };
+
 export interface SubscriptionAuthorizer {
     verifyDistributionOrIntersect(
         userIdentity: UserIdentity | null,
         specification: Specification,
         namedStart: ReferencesByName
-    ): Promise<DistributionIntersectionBranch[]>;
+    ): Promise<DistributionBranchesResult>;
     feedPreVerified(
         userIdentity: UserIdentity | null,
         specification: Specification,
         start: FactReference[],
         bookmark: string
     ): Promise<FactFeed>;
+    feedWithDistribution(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        start: FactReference[],
+        bookmark: string
+    ): Promise<FeedResult>;
 }
 
 import { Keystore } from "../keystore";
@@ -89,6 +103,14 @@ export class AuthorizationKeystore implements Authorization, SubscriptionAuthori
     }
 
     async feed(userIdentity: UserIdentity | null, specification: Specification, start: FactReference[], bookmark: string): Promise<FactFeed> {
+        const result = await this.feedWithDistribution(userIdentity, specification, start, bookmark);
+        if (result.type === "denied") {
+            throw new Forbidden(result.reason);
+        }
+        return result.feed;
+    }
+
+    async feedWithDistribution(userIdentity: UserIdentity | null, specification: Specification, start: FactReference[], bookmark: string): Promise<FeedResult> {
         if (this.distributionEngine) {
             const userReference: FactReference | null = userIdentity
                 ? await this.keystore.getUserFact(userIdentity)
@@ -99,18 +121,16 @@ export class AuthorizationKeystore implements Authorization, SubscriptionAuthori
             }), {} as ReferencesByName);
             const canDistribute = await this.distributionEngine.canDistributeToAll([specification], namedStart, userReference);
             if (canDistribute.type === "failure") {
-                throw new Forbidden(canDistribute.reason);
+                return { type: "denied", reason: canDistribute.reason };
             }
             const factFeed = await this.store.feed(specification, start, bookmark);
             const factReferences = factFeed.tuples
                 .flatMap(tuple => tuple.facts)
                 .filter((value, index, self) => self.findIndex(factReferenceEquals(value)) === index);
             this.distributedFacts.add(factReferences, userReference);
-            return factFeed;
+            return { type: "success", feed: factFeed };
         }
-        else {
-            return await this.store.feed(specification, start, bookmark);
-        }
+        return { type: "success", feed: await this.store.feed(specification, start, bookmark) };
     }
 
     async feedPreVerified(userIdentity: UserIdentity | null, specification: Specification, start: FactReference[], bookmark: string): Promise<FactFeed> {
@@ -208,10 +228,10 @@ export class AuthorizationKeystore implements Authorization, SubscriptionAuthori
         userIdentity: UserIdentity | null,
         specification: Specification,
         namedStart: ReferencesByName
-    ): Promise<DistributionIntersectionBranch[]> {
+    ): Promise<DistributionBranchesResult> {
         const start = specification.given.map(g => namedStart[g.label.name]);
         if (!this.distributionEngine) {
-            return [{ start, specification }];
+            return { type: "success", branches: [{ start, specification }] };
         }
         const userReference: FactReference | null = userIdentity
             ? await this.keystore.getUserFact(userIdentity)
@@ -219,12 +239,12 @@ export class AuthorizationKeystore implements Authorization, SubscriptionAuthori
         const targetFeeds = buildFeeds(specification);
         const canDistribute = await this.distributionEngine.canDistributeToAll(targetFeeds, namedStart, userReference);
         if (canDistribute.type === "success") {
-            return [{ start, specification }];
+            return { type: "success", branches: [{ start, specification }] };
         }
         const result = await this.distributionEngine.intersectForSubscribe(start, specification, userReference);
         if (!result.intersected) {
-            throw new Forbidden(canDistribute.reason);
+            return { type: "denied", reason: canDistribute.reason };
         }
-        return result.branches;
+        return { type: "success", branches: result.branches };
     }
 }

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -27,11 +27,13 @@ import {
     ProjectedResult,
     ReferencesByName,
     Specification,
+    SpecificationListener,
     SpecificationParser,
     Trace,
     UserIdentity,
     verifyEnvelopes
 } from "jinaga";
+import { DistributionIntersectionBranch } from "../authorization/authorization-keystore";
 import { CsvMetadata } from "./csv-metadata";
 import { validateSpecificationForCsv } from "./csv-validator";
 import { createLineReader } from "./line-reader";
@@ -364,12 +366,30 @@ export interface RequestUser {
     profile: ProfileMessage;
 }
 
+export interface SubscriptionAuthorizer {
+    verifyDistributionOrIntersect(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        namedStart: ReferencesByName
+    ): Promise<DistributionIntersectionBranch[]>;
+    feedPreVerified(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        start: FactReference[],
+        bookmark: string
+    ): Promise<import("jinaga").FactFeed>;
+}
+
 export class HttpRouter {
     handler: Handler;
+    // Set of feed hashes the server has cleared via intersection. Queries
+    // against these hashes skip the per-request distribution check because
+    // their cached spec self-filters by the lifted auth condition.
+    private intersectedFeedHashes = new Set<string>();
 
     constructor(
         private factManager: FactManager,
-        private authorization: Authorization,
+        private authorization: Authorization & Partial<SubscriptionAuthorizer>,
         private feedCache: FeedCache,
         private allowedOrigin: string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void)
     ) {
@@ -555,23 +575,69 @@ export class HttpRouter {
             if (failures.length > 0) {
                 throw new Invalid(failures.join("\n"));
             }
-            
+
             const namedStart = specification.given.reduce((map, g, index) => ({
                 ...map,
                 [g.label.name]: start[index]
             }), {} as ReferencesByName);
 
-            // Verify that I can distribute all feeds to the user.
-            const feeds = buildFeeds(specification);
+            // Resolve distribution. When the user is not authorized for the
+            // original spec but the distribution rules can rewrite it via
+            // intersection (jinaga.js#130), accept the subscription with
+            // empty results and let the inverse engine activate it later.
             const userIdentity = serializeUserIdentity(user);
-            await this.authorization.verifyDistribution(userIdentity, feeds, namedStart);
+            const branches = await this.resolveSubscriptionBranches(userIdentity, specification, namedStart);
+            const intersected = branches.length !== 1 || branches[0].specification !== specification;
 
-            const feedHashes = this.feedCache.addFeeds(feeds, namedStart);
+            const feedHashes: string[] = [];
+            for (const branch of branches) {
+                const branchNamedStart = branch.specification.given.reduce((map, g, index) => ({
+                    ...map,
+                    [g.label.name]: branch.start[index]
+                }), {} as ReferencesByName);
+                const branchFeeds = buildFeeds(branch.specification);
+                const branchHashes = this.feedCache.addFeeds(branchFeeds, branchNamedStart);
+                feedHashes.push(...branchHashes);
+                if (intersected) {
+                    for (const hash of branchHashes) {
+                        this.intersectedFeedHashes.add(hash);
+                    }
+                }
+            }
 
             return {
                 feeds: feedHashes
             }
         });
+    }
+
+    private queryFeed(
+        feedHash: string,
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        start: FactReference[],
+        bookmark: string
+    ): Promise<import("jinaga").FactFeed> {
+        if (this.intersectedFeedHashes.has(feedHash) && this.authorization.feedPreVerified) {
+            return this.authorization.feedPreVerified(userIdentity, specification, start, bookmark);
+        }
+        return this.authorization.feed(userIdentity, specification, start, bookmark);
+    }
+
+    private async resolveSubscriptionBranches(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        namedStart: ReferencesByName
+    ): Promise<DistributionIntersectionBranch[]> {
+        const start = specification.given.map(g => namedStart[g.label.name]);
+        if (this.authorization.verifyDistributionOrIntersect) {
+            return await this.authorization.verifyDistributionOrIntersect(userIdentity, specification, namedStart);
+        }
+        // Fall back to plain verification for Authorization implementations
+        // that don't expose the intersect path.
+        const feeds = buildFeeds(specification);
+        await this.authorization.verifyDistribution(userIdentity, feeds, namedStart);
+        return [{ start, specification }];
     }
 
     private feed(user: RequestUser | null, params: { [key: string]: string }, query: qs.ParsedQs): Promise<FeedResponse | null> {
@@ -590,7 +656,7 @@ export class HttpRouter {
 
             const userIdentity = serializeUserIdentity(user);
             const start = feedDefinition.feed.given.map(g => feedDefinition.namedStart[g.label.name]);
-            const results = await this.authorization.feed(userIdentity, feedDefinition.feed, start, bookmark);
+            const results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
             // Return distinct fact references from all the tuples.
             const references = results.tuples.flatMap(t => t.facts).filter((value, index, self) =>
                 self.findIndex(f => f.hash === value.hash && f.type === value.type) === index
@@ -636,7 +702,7 @@ export class HttpRouter {
             // Continuous initial query until exhausted
             console.log(`[StreamFeed:${connectionId}] Starting initial data streaming...`);
             const initialStart = Date.now();
-            bookmark = await this.streamAllInitialResults(userIdentity, feedDefinition, start, bookmark, stream);
+            bookmark = await this.streamAllInitialResults(feedHash, userIdentity, feedDefinition, start, bookmark, stream);
             const initialDuration = Date.now() - initialStart;
             console.log(`[StreamFeed:${connectionId}] Initial data streaming complete - Duration: ${initialDuration}ms, Final bookmark: ${bookmark || 'empty'}`);
             
@@ -664,7 +730,7 @@ export class HttpRouter {
                             if (matchingResults.length != 0) {
                                 console.log(`[StreamFeed:${connectionId}] Processing matching results...`);
                                 const responseStart = Date.now();
-                                bookmark = await this.streamFeedResponse(userIdentity, feedDefinition, start, bookmark, stream, true);
+                                bookmark = await this.streamFeedResponse(feedHash, userIdentity, feedDefinition, start, bookmark, stream, true);
                                 const responseDuration = Date.now() - responseStart;
                                 console.log(`[StreamFeed:${connectionId}] Feed response sent - Duration: ${responseDuration}ms, New bookmark: ${bookmark || 'empty'}`);
                             } else {
@@ -714,6 +780,7 @@ export class HttpRouter {
     }
 
     private async streamAllInitialResults(
+        feedHash: string,
         userIdentity: UserIdentity | null,
         feedDefinition: FeedObject,
         start: FactReference[],
@@ -734,7 +801,7 @@ export class HttpRouter {
             const pageStart = Date.now();
             console.log(`[InitialResults:${streamId}] Fetching page ${pageCount + 1} - Bookmark: ${bookmark || 'empty'}`);
             
-            const results = await this.authorization.feed(userIdentity, feedDefinition.feed, start, bookmark);
+            const results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
             const fetchDuration = Date.now() - pageStart;
             
             console.log(`[InitialResults:${streamId}] Page ${pageCount + 1} fetched - Tuples: ${results.tuples.length}, Duration: ${fetchDuration}ms`);
@@ -803,14 +870,14 @@ export class HttpRouter {
         return bookmark;
     }
 
-    private async streamFeedResponse(userIdentity: UserIdentity | null, feedDefinition: FeedObject, start: FactReference[], bookmark: string, stream: Stream<FeedResponse>, skipIfEmpty = false): Promise<string> {
+    private async streamFeedResponse(feedHash: string, userIdentity: UserIdentity | null, feedDefinition: FeedObject, start: FactReference[], bookmark: string, stream: Stream<FeedResponse>, skipIfEmpty = false): Promise<string> {
         const responseId = Math.random().toString(36).substring(2, 6);
         const startTime = Date.now();
         
         console.log(`[FeedResponse:${responseId}] Starting feed response - Bookmark: ${bookmark || 'empty'}, Skip if empty: ${skipIfEmpty}`);
         
         const feedStart = Date.now();
-        const results = await this.authorization.feed(userIdentity, feedDefinition.feed, start, bookmark);
+        const results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
         const feedDuration = Date.now() - feedStart;
         
         console.log(`[FeedResponse:${responseId}] Authorization feed complete - Tuples: ${results.tuples.length}, Duration: ${feedDuration}ms`);

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -33,7 +33,7 @@ import {
     UserIdentity,
     verifyEnvelopes
 } from "jinaga";
-import { DistributionIntersectionBranch } from "../authorization/authorization-keystore";
+import { DistributionIntersectionBranch, SubscriptionAuthorizer } from "../authorization/authorization-keystore";
 import { CsvMetadata } from "./csv-metadata";
 import { validateSpecificationForCsv } from "./csv-validator";
 import { createLineReader } from "./line-reader";
@@ -370,20 +370,6 @@ export interface RequestUser {
     profile: ProfileMessage;
 }
 
-export interface SubscriptionAuthorizer {
-    verifyDistributionOrIntersect(
-        userIdentity: UserIdentity | null,
-        specification: Specification,
-        namedStart: ReferencesByName
-    ): Promise<DistributionIntersectionBranch[]>;
-    feedPreVerified(
-        userIdentity: UserIdentity | null,
-        specification: Specification,
-        start: FactReference[],
-        bookmark: string
-    ): Promise<import("jinaga").FactFeed>;
-}
-
 export class HttpRouter {
     handler: Handler;
     // Map from feed hash → owning user key, for feeds the server cleared
@@ -398,7 +384,7 @@ export class HttpRouter {
 
     constructor(
         private factManager: FactManager,
-        private authorization: Authorization & Partial<SubscriptionAuthorizer>,
+        private authorization: Authorization & SubscriptionAuthorizer,
         private feedCache: FeedCache,
         private allowedOrigin: string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void)
     ) {
@@ -654,9 +640,7 @@ export class HttpRouter {
     ): Promise<import("jinaga").FactFeed> {
         const cachedOwner = this.intersectedFeedOwners.get(feedHash);
         const requesterOwner = subscriptionOwnerKey(userIdentity);
-        if (cachedOwner !== undefined
-            && cachedOwner === requesterOwner
-            && this.authorization.feedPreVerified) {
+        if (cachedOwner !== undefined && cachedOwner === requesterOwner) {
             return this.authorization.feedPreVerified(userIdentity, specification, start, bookmark);
         }
         // For everyone else (different user, anonymous mismatch, or a

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -749,11 +749,45 @@ export class HttpRouter {
             });
             
             console.log(`[StreamFeed:${connectionId}] All listeners registered - Count: ${listeners.length}`);
-            
+
+            // Anchor listeners (jinaga.js#129): the inverse-listener path
+            // above only fires when a descendant of the given arrives. If
+            // the given fact itself isn't yet in the store when the client
+            // subscribes, neither the initial query nor any later inverse
+            // can deliver results until the given is recorded — and the
+            // given fact has no descendants whose save would re-trigger the
+            // inverse with the matching givenHash. Register a listener per
+            // unique anchor that re-runs streamFeedResponse the moment a
+            // saved fact matches the anchor's (type, hash).
+            const uniqueAnchors = start.filter((s, i, arr) =>
+                arr.findIndex(other => other.type === s.type && other.hash === s.hash) === i);
+            console.log(`[StreamFeed:${connectionId}] Registering ${uniqueAnchors.length} anchor listener(s)`);
+            const anchorListeners = uniqueAnchors.map(anchor => {
+                const anchorSpec: Specification = {
+                    given: [{ label: { name: "x", type: anchor.type }, conditions: [] }],
+                    matches: [],
+                    projection: { type: "fact", label: "x" }
+                };
+                return this.factManager.addSpecificationListener(anchorSpec, async (results) => {
+                    try {
+                        const matched = results.some(pr => {
+                            const ref = pr.tuple && (pr.tuple as any).x;
+                            return ref && ref.type === anchor.type && ref.hash === anchor.hash;
+                        });
+                        if (matched) {
+                            console.log(`[StreamFeed:${connectionId}] Anchor fact arrived - Type: ${anchor.type}, Hash: ${anchor.hash.substring(0, 8)}...`);
+                            bookmark = await this.streamFeedResponse(feedHash, userIdentity, feedDefinition, start, bookmark, stream, true);
+                        }
+                    } catch (error) {
+                        console.error(`[StreamFeed:${connectionId}] ERROR in anchor listener: ${error}`);
+                    }
+                });
+            });
+
             stream.done(() => {
                 const cleanupStart = Date.now();
-                console.log(`[StreamFeed:${connectionId}] CLEANUP STARTED - Removing ${listeners.length} listeners`);
-                
+                console.log(`[StreamFeed:${connectionId}] CLEANUP STARTED - Removing ${listeners.length + anchorListeners.length} listener(s)`);
+
                 for (let i = 0; i < listeners.length; i++) {
                     try {
                         this.factManager.removeSpecificationListener(listeners[i]);
@@ -762,7 +796,14 @@ export class HttpRouter {
                         console.error(`[StreamFeed:${connectionId}] ERROR removing listener ${i + 1}: ${error}`);
                     }
                 }
-                
+                for (let i = 0; i < anchorListeners.length; i++) {
+                    try {
+                        this.factManager.removeSpecificationListener(anchorListeners[i]);
+                    } catch (error) {
+                        console.error(`[StreamFeed:${connectionId}] ERROR removing anchor listener ${i + 1}: ${error}`);
+                    }
+                }
+
                 const cleanupDuration = Date.now() - cleanupStart;
                 const totalDuration = Date.now() - startTime;
                 console.log(`[StreamFeed:${connectionId}] CLEANUP COMPLETE - Cleanup duration: ${cleanupDuration}ms, Total connection duration: ${totalDuration}ms`);

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -620,6 +620,19 @@ export class HttpRouter {
                         // the cached spec — which carries the original
                         // owner's user fact in its start — to fetch
                         // facts authorized for that owner.
+                        //
+                        // The map allows only one owner per hash, which
+                        // relies on the invariant that intersected specs
+                        // bind the requesting user's fact into start —
+                        // making the hash user-specific. If two distinct
+                        // owners ever collide on the same hash, that
+                        // invariant has broken in intersectForSubscribe;
+                        // warn so we notice instead of silently
+                        // overwriting.
+                        const existing = this.intersectedFeedOwners.get(hash);
+                        if (existing !== undefined && existing !== ownerKey) {
+                            Trace.warn(`Intersected feed hash ${hash} re-bound from owner ${existing} to ${ownerKey}; intersection invariant may be broken`);
+                        }
                         this.intersectedFeedOwners.set(hash, ownerKey);
                     }
                 }

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -27,7 +27,6 @@ import {
     ProjectedResult,
     ReferencesByName,
     Specification,
-    SpecificationListener,
     SpecificationParser,
     Trace,
     UserIdentity,
@@ -584,9 +583,9 @@ export class HttpRouter {
             // Even when no rule applies at all, accept the subscription:
             // the per-query distribution check inside streamFeed /
             // feed catches Forbidden and keeps the stream alive so the
-            // client can be notified the moment the authorizing fact does
-            // arrive (or a matching rule is added). Failing /feeds here
-            // would force the client to re-subscribe on a poll loop.
+            // client can be notified the moment the authorizing fact
+            // arrives. Failing /feeds here would force the client to
+            // re-subscribe on a poll loop.
             const userIdentity = serializeUserIdentity(user);
             let branches: DistributionIntersectionBranch[];
             let intersected: boolean;

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -32,7 +32,7 @@ import {
     UserIdentity,
     verifyEnvelopes
 } from "jinaga";
-import { DistributionIntersectionBranch, SubscriptionAuthorizer } from "../authorization/authorization-keystore";
+import { DistributionIntersectionBranch, FeedResult, SubscriptionAuthorizer } from "../authorization/authorization-keystore";
 import { CsvMetadata } from "./csv-metadata";
 import { validateSpecificationForCsv } from "./csv-validator";
 import { createLineReader } from "./line-reader";
@@ -582,24 +582,21 @@ export class HttpRouter {
             //
             // Even when no rule applies at all, accept the subscription:
             // the per-query distribution check inside streamFeed /
-            // feed catches Forbidden and keeps the stream alive so the
+            // feed returns "denied" and keeps the stream alive so the
             // client can be notified the moment the authorizing fact
             // arrives. Failing /feeds here would force the client to
             // re-subscribe on a poll loop.
             const userIdentity = serializeUserIdentity(user);
+            const intersectResult = await this.authorization.verifyDistributionOrIntersect(userIdentity, specification, namedStart);
             let branches: DistributionIntersectionBranch[];
             let intersected: boolean;
-            try {
-                branches = await this.resolveSubscriptionBranches(userIdentity, specification, namedStart);
+            if (intersectResult.type === "denied") {
+                Trace.warn(`/feeds accepting spec without applicable distribution rule: ${intersectResult.reason}`);
+                branches = [{ start, specification }];
+                intersected = false;
+            } else {
+                branches = intersectResult.branches;
                 intersected = branches.length !== 1 || branches[0].specification !== specification;
-            } catch (error) {
-                if (error instanceof Forbidden) {
-                    Trace.warn(`/feeds accepting spec without applicable distribution rule: ${error.message}`);
-                    branches = [{ start, specification }];
-                    intersected = false;
-                } else {
-                    throw error;
-                }
             }
 
             const ownerKey = subscriptionOwnerKey(userIdentity);
@@ -643,39 +640,24 @@ export class HttpRouter {
         });
     }
 
-    private queryFeed(
+    private async queryFeed(
         feedHash: string,
         userIdentity: UserIdentity | null,
         specification: Specification,
         start: FactReference[],
         bookmark: string
-    ): Promise<import("jinaga").FactFeed> {
+    ): Promise<FeedResult> {
         const cachedOwner = this.intersectedFeedOwners.get(feedHash);
         const requesterOwner = subscriptionOwnerKey(userIdentity);
         if (cachedOwner !== undefined && cachedOwner === requesterOwner) {
-            return this.authorization.feedPreVerified(userIdentity, specification, start, bookmark);
+            const feed = await this.authorization.feedPreVerified(userIdentity, specification, start, bookmark);
+            return { type: "success", feed };
         }
         // For everyone else (different user, anonymous mismatch, or a
         // non-intersected hash) go through the normal distribution-checked
-        // path. If that user isn't authorized, Forbidden propagates and
-        // the streaming / polling caller turns it into an empty page.
-        return this.authorization.feed(userIdentity, specification, start, bookmark);
-    }
-
-    private async resolveSubscriptionBranches(
-        userIdentity: UserIdentity | null,
-        specification: Specification,
-        namedStart: ReferencesByName
-    ): Promise<DistributionIntersectionBranch[]> {
-        const start = specification.given.map(g => namedStart[g.label.name]);
-        if (this.authorization.verifyDistributionOrIntersect) {
-            return await this.authorization.verifyDistributionOrIntersect(userIdentity, specification, namedStart);
-        }
-        // Fall back to plain verification for Authorization implementations
-        // that don't expose the intersect path.
-        const feeds = buildFeeds(specification);
-        await this.authorization.verifyDistribution(userIdentity, feeds, namedStart);
-        return [{ start, specification }];
+        // path. A "denied" result means the streaming / polling caller
+        // serves an empty page and keeps the subscription alive.
+        return await this.authorization.feedWithDistribution(userIdentity, specification, start, bookmark);
     }
 
     private feed(user: RequestUser | null, params: { [key: string]: string }, query: qs.ParsedQs): Promise<FeedResponse | null> {
@@ -694,26 +676,21 @@ export class HttpRouter {
 
             const userIdentity = serializeUserIdentity(user);
             const start = feedDefinition.feed.given.map(g => feedDefinition.namedStart[g.label.name]);
-            let results;
-            try {
-                results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
-            } catch (error) {
-                if (error instanceof Forbidden) {
-                    // The subscription has been accepted; treat poll-time
-                    // distribution failures as an empty page so the client
-                    // can keep polling and pick up results when an
-                    // authorizing fact arrives.
-                    return { references: [], bookmark } as FeedResponse;
-                }
-                throw error;
+            const result = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+            if (result.type === "denied") {
+                // The subscription has been accepted; treat poll-time
+                // distribution failures as an empty page so the client
+                // can keep polling and pick up results when an
+                // authorizing fact arrives.
+                return { references: [], bookmark } as FeedResponse;
             }
             // Return distinct fact references from all the tuples.
-            const references = results.tuples.flatMap(t => t.facts).filter((value, index, self) =>
+            const references = result.feed.tuples.flatMap(t => t.facts).filter((value, index, self) =>
                 self.findIndex(f => f.hash === value.hash && f.type === value.type) === index
             );
             const response: FeedResponse = {
                 references,
-                bookmark: results.bookmark
+                bookmark: result.feed.bookmark
             };
             return response;
         });
@@ -892,23 +869,19 @@ export class HttpRouter {
             const pageStart = Date.now();
             console.log(`[InitialResults:${streamId}] Fetching page ${pageCount + 1} - Bookmark: ${bookmark || 'empty'}`);
 
-            let results;
-            try {
-                results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
-            } catch (error) {
-                if (error instanceof Forbidden) {
-                    // The subscription has already been accepted; tearing
-                    // down the stream on a distribution failure would force
-                    // the client to re-subscribe just to keep waiting.
-                    // Treat as empty and let the listener path re-evaluate
-                    // when an authorizing fact arrives.
-                    console.log(`[InitialResults:${streamId}] Distribution failed (${error.message}) - serving empty and keeping stream live`);
-                    return bookmark;
-                }
-                throw error;
+            const queryResult = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+            if (queryResult.type === "denied") {
+                // The subscription has already been accepted; tearing
+                // down the stream on a distribution failure would force
+                // the client to re-subscribe just to keep waiting.
+                // Treat as empty and let the listener path re-evaluate
+                // when an authorizing fact arrives.
+                console.log(`[InitialResults:${streamId}] Distribution failed (${queryResult.reason}) - serving empty and keeping stream live`);
+                return bookmark;
             }
+            const results = queryResult.feed;
             const fetchDuration = Date.now() - pageStart;
-            
+
             console.log(`[InitialResults:${streamId}] Page ${pageCount + 1} fetched - Tuples: ${results.tuples.length}, Duration: ${fetchDuration}ms`);
             
             // Check if we got results
@@ -982,19 +955,15 @@ export class HttpRouter {
         console.log(`[FeedResponse:${responseId}] Starting feed response - Bookmark: ${bookmark || 'empty'}, Skip if empty: ${skipIfEmpty}`);
         
         const feedStart = Date.now();
-        let results;
-        try {
-            results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
-        } catch (error) {
-            if (error instanceof Forbidden) {
-                // The subscription stays live across distribution failures
-                // so the inverse / anchor listeners can deliver results
-                // once the authorizing fact arrives.
-                console.log(`[FeedResponse:${responseId}] Distribution failed (${error.message}) - keeping stream live`);
-                return bookmark;
-            }
-            throw error;
+        const queryResult = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+        if (queryResult.type === "denied") {
+            // The subscription stays live across distribution failures
+            // so the inverse / anchor listeners can deliver results
+            // once the authorizing fact arrives.
+            console.log(`[FeedResponse:${responseId}] Distribution failed (${queryResult.reason}) - keeping stream live`);
+            return bookmark;
         }
+        const results = queryResult.feed;
         const feedDuration = Date.now() - feedStart;
 
         console.log(`[FeedResponse:${responseId}] Authorization feed complete - Tuples: ${results.tuples.length}, Duration: ${feedDuration}ms`);

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -585,9 +585,28 @@ export class HttpRouter {
             // original spec but the distribution rules can rewrite it via
             // intersection (jinaga.js#130), accept the subscription with
             // empty results and let the inverse engine activate it later.
+            //
+            // Even when no rule applies at all, accept the subscription:
+            // the per-query distribution check inside streamFeed /
+            // feed catches Forbidden and keeps the stream alive so the
+            // client can be notified the moment the authorizing fact does
+            // arrive (or a matching rule is added). Failing /feeds here
+            // would force the client to re-subscribe on a poll loop.
             const userIdentity = serializeUserIdentity(user);
-            const branches = await this.resolveSubscriptionBranches(userIdentity, specification, namedStart);
-            const intersected = branches.length !== 1 || branches[0].specification !== specification;
+            let branches: DistributionIntersectionBranch[];
+            let intersected: boolean;
+            try {
+                branches = await this.resolveSubscriptionBranches(userIdentity, specification, namedStart);
+                intersected = branches.length !== 1 || branches[0].specification !== specification;
+            } catch (error) {
+                if (error instanceof Forbidden) {
+                    Trace.warn(`/feeds accepting spec without applicable distribution rule: ${error.message}`);
+                    branches = [{ start, specification }];
+                    intersected = false;
+                } else {
+                    throw error;
+                }
+            }
 
             const feedHashes: string[] = [];
             for (const branch of branches) {
@@ -656,7 +675,19 @@ export class HttpRouter {
 
             const userIdentity = serializeUserIdentity(user);
             const start = feedDefinition.feed.given.map(g => feedDefinition.namedStart[g.label.name]);
-            const results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+            let results;
+            try {
+                results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+            } catch (error) {
+                if (error instanceof Forbidden) {
+                    // The subscription has been accepted; treat poll-time
+                    // distribution failures as an empty page so the client
+                    // can keep polling and pick up results when an
+                    // authorizing fact arrives.
+                    return { references: [], bookmark } as FeedResponse;
+                }
+                throw error;
+            }
             // Return distinct fact references from all the tuples.
             const references = results.tuples.flatMap(t => t.facts).filter((value, index, self) =>
                 self.findIndex(f => f.hash === value.hash && f.type === value.type) === index
@@ -841,8 +872,22 @@ export class HttpRouter {
         while (hasMoreResults && pageCount < maxPages) {
             const pageStart = Date.now();
             console.log(`[InitialResults:${streamId}] Fetching page ${pageCount + 1} - Bookmark: ${bookmark || 'empty'}`);
-            
-            const results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+
+            let results;
+            try {
+                results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+            } catch (error) {
+                if (error instanceof Forbidden) {
+                    // The subscription has already been accepted; tearing
+                    // down the stream on a distribution failure would force
+                    // the client to re-subscribe just to keep waiting.
+                    // Treat as empty and let the listener path re-evaluate
+                    // when an authorizing fact arrives.
+                    console.log(`[InitialResults:${streamId}] Distribution failed (${error.message}) - serving empty and keeping stream live`);
+                    return bookmark;
+                }
+                throw error;
+            }
             const fetchDuration = Date.now() - pageStart;
             
             console.log(`[InitialResults:${streamId}] Page ${pageCount + 1} fetched - Tuples: ${results.tuples.length}, Duration: ${fetchDuration}ms`);
@@ -918,9 +963,21 @@ export class HttpRouter {
         console.log(`[FeedResponse:${responseId}] Starting feed response - Bookmark: ${bookmark || 'empty'}, Skip if empty: ${skipIfEmpty}`);
         
         const feedStart = Date.now();
-        const results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+        let results;
+        try {
+            results = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
+        } catch (error) {
+            if (error instanceof Forbidden) {
+                // The subscription stays live across distribution failures
+                // so the inverse / anchor listeners can deliver results
+                // once the authorizing fact arrives.
+                console.log(`[FeedResponse:${responseId}] Distribution failed (${error.message}) - keeping stream live`);
+                return bookmark;
+            }
+            throw error;
+        }
         const feedDuration = Date.now() - feedStart;
-        
+
         console.log(`[FeedResponse:${responseId}] Authorization feed complete - Tuples: ${results.tuples.length}, Duration: ${feedDuration}ms`);
         
         // Return distinct fact references from all the tuples.

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -288,6 +288,10 @@ function postReadWithStreaming(
     };
 }
 
+function subscriptionOwnerKey(userIdentity: UserIdentity | null): string | null {
+    return userIdentity ? `${userIdentity.provider}|${userIdentity.id}` : null;
+}
+
 function serializeUserIdentity(user: RequestUser | null): UserIdentity | null {
     if (!user) {
         return null;
@@ -382,10 +386,15 @@ export interface SubscriptionAuthorizer {
 
 export class HttpRouter {
     handler: Handler;
-    // Set of feed hashes the server has cleared via intersection. Queries
-    // against these hashes skip the per-request distribution check because
-    // their cached spec self-filters by the lifted auth condition.
-    private intersectedFeedHashes = new Set<string>();
+    // Map from feed hash → owning user key, for feeds the server cleared
+    // via intersection. The cached spec self-filters by the lifted auth
+    // condition (the requesting user's fact is baked into start), so it
+    // is safe to skip the per-query distribution check — but ONLY for
+    // the same user who originally requested the subscription. Another
+    // authenticated user who somehow obtained the hash must go through
+    // the normal authorization.feed path, which will deny their request
+    // since the intersected spec is not authorizable in its own right.
+    private intersectedFeedOwners = new Map<string, string | null>();
 
     constructor(
         private factManager: FactManager,
@@ -608,6 +617,7 @@ export class HttpRouter {
                 }
             }
 
+            const ownerKey = subscriptionOwnerKey(userIdentity);
             const feedHashes: string[] = [];
             for (const branch of branches) {
                 const branchNamedStart = branch.specification.given.reduce((map, g, index) => ({
@@ -619,7 +629,12 @@ export class HttpRouter {
                 feedHashes.push(...branchHashes);
                 if (intersected) {
                     for (const hash of branchHashes) {
-                        this.intersectedFeedHashes.add(hash);
+                        // Bind the hash to its owner so a different
+                        // authenticated user who obtains it cannot reuse
+                        // the cached spec — which carries the original
+                        // owner's user fact in its start — to fetch
+                        // facts authorized for that owner.
+                        this.intersectedFeedOwners.set(hash, ownerKey);
                     }
                 }
             }
@@ -637,9 +652,17 @@ export class HttpRouter {
         start: FactReference[],
         bookmark: string
     ): Promise<import("jinaga").FactFeed> {
-        if (this.intersectedFeedHashes.has(feedHash) && this.authorization.feedPreVerified) {
+        const cachedOwner = this.intersectedFeedOwners.get(feedHash);
+        const requesterOwner = subscriptionOwnerKey(userIdentity);
+        if (cachedOwner !== undefined
+            && cachedOwner === requesterOwner
+            && this.authorization.feedPreVerified) {
             return this.authorization.feedPreVerified(userIdentity, specification, start, bookmark);
         }
+        // For everyone else (different user, anonymous mismatch, or a
+        // non-intersected hash) go through the normal distribution-checked
+        // path. If that user isn't authorized, Forbidden propagates and
+        // the streaming / polling caller turns it into an empty page.
         return this.authorization.feed(userIdentity, specification, start, bookmark);
     }
 

--- a/src/jinaga-server.ts
+++ b/src/jinaga-server.ts
@@ -5,7 +5,9 @@ import {
     AuthorizationNoOp,
     AuthorizationRules,
     DistributionRules,
+    FactFeed,
     FactManager,
+    FactReference,
     FeedCache,
     FetchConnection,
     Fork,
@@ -20,6 +22,7 @@ import {
     PassThroughFork,
     PersistentFork,
     PurgeConditions,
+    ReferencesByName,
     Specification,
     Storage,
     SyncStatusNotifier,
@@ -33,7 +36,7 @@ import { Pool } from "pg";
 
 import { AuthenticationDevice } from "./authentication/authentication-device";
 import { AuthenticationSession } from "./authentication/authentication-session";
-import { AuthorizationKeystore } from "./authorization/authorization-keystore";
+import { AuthorizationKeystore, DistributionIntersectionBranch, SubscriptionAuthorizer } from "./authorization/authorization-keystore";
 import { HttpRouter, RequestUser } from "./http/router";
 import { Keystore } from "./keystore";
 import { PostgresKeystore } from "./postgres/postgres-keystore";
@@ -186,13 +189,33 @@ function createKeystore(config: JinagaServerConfig, pools: { [uri: string]: Pool
     }
 }
 
-function createAuthorization(authorizationRules: AuthorizationRules | null, distributionRules: DistributionRules | null, factManager: FactManager, store: Storage, keystore: Keystore | null): Authorization {
+class AuthorizationNoOpWithSubscriptions extends AuthorizationNoOp implements SubscriptionAuthorizer {
+    async verifyDistributionOrIntersect(
+        _userIdentity: UserIdentity | null,
+        specification: Specification,
+        namedStart: ReferencesByName
+    ): Promise<DistributionIntersectionBranch[]> {
+        const start = specification.given.map(g => namedStart[g.label.name]);
+        return [{ start, specification }];
+    }
+
+    feedPreVerified(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        start: FactReference[],
+        bookmark: string
+    ): Promise<FactFeed> {
+        return this.feed(userIdentity!, specification, start, bookmark);
+    }
+}
+
+function createAuthorization(authorizationRules: AuthorizationRules | null, distributionRules: DistributionRules | null, factManager: FactManager, store: Storage, keystore: Keystore | null): Authorization & SubscriptionAuthorizer {
     if (keystore) {
         const authorization = new AuthorizationKeystore(factManager, store, keystore, authorizationRules, distributionRules);
         return authorization;
     }
     else {
-        return new AuthorizationNoOp(factManager, store);
+        return new AuthorizationNoOpWithSubscriptions(factManager, store);
     }
 }
 

--- a/src/jinaga-server.ts
+++ b/src/jinaga-server.ts
@@ -36,7 +36,7 @@ import { Pool } from "pg";
 
 import { AuthenticationDevice } from "./authentication/authentication-device";
 import { AuthenticationSession } from "./authentication/authentication-session";
-import { AuthorizationKeystore, DistributionIntersectionBranch, SubscriptionAuthorizer } from "./authorization/authorization-keystore";
+import { AuthorizationKeystore, DistributionBranchesResult, FeedResult, SubscriptionAuthorizer } from "./authorization/authorization-keystore";
 import { HttpRouter, RequestUser } from "./http/router";
 import { Keystore } from "./keystore";
 import { PostgresKeystore } from "./postgres/postgres-keystore";
@@ -194,9 +194,9 @@ class AuthorizationNoOpWithSubscriptions extends AuthorizationNoOp implements Su
         _userIdentity: UserIdentity | null,
         specification: Specification,
         namedStart: ReferencesByName
-    ): Promise<DistributionIntersectionBranch[]> {
+    ): Promise<DistributionBranchesResult> {
         const start = specification.given.map(g => namedStart[g.label.name]);
-        return [{ start, specification }];
+        return { type: "success", branches: [{ start, specification }] };
     }
 
     feedPreVerified(
@@ -206,6 +206,16 @@ class AuthorizationNoOpWithSubscriptions extends AuthorizationNoOp implements Su
         bookmark: string
     ): Promise<FactFeed> {
         return this.feed(userIdentity!, specification, start, bookmark);
+    }
+
+    async feedWithDistribution(
+        userIdentity: UserIdentity | null,
+        specification: Specification,
+        start: FactReference[],
+        bookmark: string
+    ): Promise<FeedResult> {
+        const feed = await this.feed(userIdentity!, specification, start, bookmark);
+        return { type: "success", feed };
     }
 }
 

--- a/src/memory/memory-keystore.ts
+++ b/src/memory/memory-keystore.ts
@@ -75,6 +75,6 @@ export class MemoryKeystore implements Keystore {
     private generateKeyPair(key: string) {
         const keyPair = generateKeyPair();
         this.keyPairs[key] = keyPair;
-        return keyPair.privatePem;
+        return keyPair.publicPem;
     }
 }

--- a/test/authorization/subscriptionIntersectionSpec.ts
+++ b/test/authorization/subscriptionIntersectionSpec.ts
@@ -4,7 +4,6 @@ import {
     dehydrateFact,
     DistributionRules,
     FactManager,
-    hydrate,
     MemoryStore,
     NetworkNoOp,
     ObservableSource,
@@ -61,12 +60,14 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
             .find(f => f.type === Company.Type)!;
         const namedStart: ReferencesByName = { [officeSpec.given[0].label.name]: companyRef };
 
-        const branches = await setup.authorization.verifyDistributionOrIntersect(
+        const result = await setup.authorization.verifyDistributionOrIntersect(
             subscriberIdentity, officeSpec, namedStart);
 
-        expect(branches).toHaveLength(1);
-        expect(branches[0].specification).toBe(officeSpec);
-        expect(branches[0].start).toEqual([companyRef]);
+        expect(result.type).toBe("success");
+        if (result.type !== "success") return;
+        expect(result.branches).toHaveLength(1);
+        expect(result.branches[0].specification).toBe(officeSpec);
+        expect(result.branches[0].start).toEqual([companyRef]);
     });
 
     it("returns intersected branches when the user is not yet authorized", async () => {
@@ -83,23 +84,25 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
             .find(f => f.type === Company.Type)!;
         const namedStart: ReferencesByName = { [officeSpec.given[0].label.name]: companyRef };
 
-        const branches = await setup.authorization.verifyDistributionOrIntersect(
+        const result = await setup.authorization.verifyDistributionOrIntersect(
             subscriberIdentity, officeSpec, namedStart);
 
         // Intersection produced an alternate branch that lifts the rule's
         // user-spec into the subscription. The intersected spec has an
         // additional synthetic given and a different shape than the original.
-        expect(branches.length).toBeGreaterThanOrEqual(1);
-        expect(branches[0].specification).not.toBe(officeSpec);
-        expect(branches[0].specification.given.length).toBe(2);
+        expect(result.type).toBe("success");
+        if (result.type !== "success") return;
+        expect(result.branches.length).toBeGreaterThanOrEqual(1);
+        expect(result.branches[0].specification).not.toBe(officeSpec);
+        expect(result.branches[0].specification.given.length).toBe(2);
         // The synthetic given is bound to the subscriber's user fact.
-        expect(branches[0].start[1]).toEqual({
+        expect(result.branches[0].start[1]).toEqual({
             type: setup.subscriberFact.type,
             hash: setup.subscriberFact.hash
         });
     });
 
-    it("throws Forbidden when no distribution rule applies to the spec", async () => {
+    it("returns denied when no distribution rule applies to the spec", async () => {
         const setup = await givenAuthorizationWithDistribution(true, async (_subscriber, creator) => {
             const company = new Company(creator, "Acme");
             return { company };
@@ -113,10 +116,12 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
             .find(f => f.type === Company.Type)!;
         const namedStart: ReferencesByName = { [unrelatedSpec.given[0].label.name]: companyRef };
 
-        await expect(
-            setup.authorization.verifyDistributionOrIntersect(
-                subscriberIdentity, unrelatedSpec, namedStart)
-        ).rejects.toThrow();
+        const result = await setup.authorization.verifyDistributionOrIntersect(
+            subscriberIdentity, unrelatedSpec, namedStart);
+
+        expect(result.type).toBe("denied");
+        if (result.type !== "denied") return;
+        expect(result.reason).toBeTruthy();
     });
 
     it("returns a passthrough branch when there are no distribution rules at all", async () => {
@@ -132,11 +137,13 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
             .find(f => f.type === Company.Type)!;
         const namedStart: ReferencesByName = { [officeSpec.given[0].label.name]: companyRef };
 
-        const branches = await setup.authorization.verifyDistributionOrIntersect(
+        const result = await setup.authorization.verifyDistributionOrIntersect(
             subscriberIdentity, officeSpec, namedStart);
 
-        expect(branches).toHaveLength(1);
-        expect(branches[0].specification).toBe(officeSpec);
+        expect(result.type).toBe("success");
+        if (result.type !== "success") return;
+        expect(result.branches).toHaveLength(1);
+        expect(result.branches[0].specification).toBe(officeSpec);
     });
 });
 

--- a/test/authorization/subscriptionIntersectionSpec.ts
+++ b/test/authorization/subscriptionIntersectionSpec.ts
@@ -1,0 +1,201 @@
+import {
+    AuthorizationRules,
+    buildModel,
+    dehydrateFact,
+    DistributionRules,
+    FactManager,
+    hydrate,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    ReferencesByName,
+    User
+} from "jinaga";
+
+import { AuthorizationKeystore } from "../../src/authorization/authorization-keystore";
+import { MemoryKeystore } from "../../src/memory/memory-keystore";
+
+class Company {
+    public static Type = "Company" as const;
+    public type = Company.Type;
+    constructor(public creator: User, public name: string) { }
+}
+
+class Office {
+    public static Type = "Office" as const;
+    public type = Office.Type;
+    constructor(public company: Company, public name: string) { }
+}
+
+class Administrator {
+    public static Type = "Administrator" as const;
+    public type = Administrator.Type;
+    constructor(public company: Company, public user: User, public createdAt: Date | string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Company, m => m.predecessor("creator", User))
+    .type(Office, m => m.predecessor("company", Company))
+    .type(Administrator, m => m
+        .predecessor("company", Company)
+        .predecessor("user", User))
+);
+
+const subscriberIdentity = { provider: "mock", id: "subscriber" };
+const creatorIdentity = { provider: "mock", id: "creator" };
+
+describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
+    it("returns the original spec when the user is already authorized", async () => {
+        const setup = await givenAuthorizationWithDistribution(true, async (subscriber, creator) => {
+            const company = new Company(creator, "Acme");
+            const admin = new Administrator(company, subscriber, new Date("2026-05-26"));
+            return { company, admin };
+        });
+
+        const officeSpec = model.given(Company).match((c, facts) =>
+            facts.ofType(Office).join(o => o.company, c)
+        ).specification;
+        const companyRef = dehydrateFact(setup.seeded.company)
+            .find(f => f.type === Company.Type)!;
+        const namedStart: ReferencesByName = { [officeSpec.given[0].label.name]: companyRef };
+
+        const branches = await setup.authorization.verifyDistributionOrIntersect(
+            subscriberIdentity, officeSpec, namedStart);
+
+        expect(branches).toHaveLength(1);
+        expect(branches[0].specification).toBe(officeSpec);
+        expect(branches[0].start).toEqual([companyRef]);
+    });
+
+    it("returns intersected branches when the user is not yet authorized", async () => {
+        const setup = await givenAuthorizationWithDistribution(true, async (subscriber, creator) => {
+            const company = new Company(creator, "Acme");
+            // No Administrator yet — subscriber is not authorized.
+            return { company };
+        });
+
+        const officeSpec = model.given(Company).match((c, facts) =>
+            facts.ofType(Office).join(o => o.company, c)
+        ).specification;
+        const companyRef = dehydrateFact(setup.seeded.company)
+            .find(f => f.type === Company.Type)!;
+        const namedStart: ReferencesByName = { [officeSpec.given[0].label.name]: companyRef };
+
+        const branches = await setup.authorization.verifyDistributionOrIntersect(
+            subscriberIdentity, officeSpec, namedStart);
+
+        // Intersection produced an alternate branch that lifts the rule's
+        // user-spec into the subscription. The intersected spec has an
+        // additional synthetic given and a different shape than the original.
+        expect(branches.length).toBeGreaterThanOrEqual(1);
+        expect(branches[0].specification).not.toBe(officeSpec);
+        expect(branches[0].specification.given.length).toBe(2);
+        // The synthetic given is bound to the subscriber's user fact.
+        expect(branches[0].start[1]).toEqual({
+            type: setup.subscriberFact.type,
+            hash: setup.subscriberFact.hash
+        });
+    });
+
+    it("throws Forbidden when no distribution rule applies to the spec", async () => {
+        const setup = await givenAuthorizationWithDistribution(true, async (_subscriber, creator) => {
+            const company = new Company(creator, "Acme");
+            return { company };
+        });
+
+        // A spec the rule doesn't cover at all (different fact type).
+        const unrelatedSpec = model.given(Company).match((c, facts) =>
+            facts.ofType(Administrator).join(a => a.company, c)
+        ).specification;
+        const companyRef = dehydrateFact(setup.seeded.company)
+            .find(f => f.type === Company.Type)!;
+        const namedStart: ReferencesByName = { [unrelatedSpec.given[0].label.name]: companyRef };
+
+        await expect(
+            setup.authorization.verifyDistributionOrIntersect(
+                subscriberIdentity, unrelatedSpec, namedStart)
+        ).rejects.toThrow();
+    });
+
+    it("returns a passthrough branch when there are no distribution rules at all", async () => {
+        const setup = await givenAuthorizationWithDistribution(false, async (_subscriber, creator) => {
+            const company = new Company(creator, "Acme");
+            return { company };
+        });
+
+        const officeSpec = model.given(Company).match((c, facts) =>
+            facts.ofType(Office).join(o => o.company, c)
+        ).specification;
+        const companyRef = dehydrateFact(setup.seeded.company)
+            .find(f => f.type === Company.Type)!;
+        const namedStart: ReferencesByName = { [officeSpec.given[0].label.name]: companyRef };
+
+        const branches = await setup.authorization.verifyDistributionOrIntersect(
+            subscriberIdentity, officeSpec, namedStart);
+
+        expect(branches).toHaveLength(1);
+        expect(branches[0].specification).toBe(officeSpec);
+    });
+});
+
+async function givenAuthorizationWithDistribution<T extends Record<string, any>>(
+    withDistributionRules: boolean,
+    buildFacts: (subscriber: User, creator: User) => Promise<T>
+) {
+    const storage = new MemoryStore();
+    const keystore = new MemoryKeystore();
+
+    const subscriberFact = await keystore.getOrCreateUserFact(subscriberIdentity);
+    const creatorFact = await keystore.getOrCreateUserFact(creatorIdentity);
+    const subscriber = new User(subscriberFact.fields.publicKey);
+    const creator = new User(creatorFact.fields.publicKey);
+
+    const seeded = await buildFacts(subscriber, creator);
+    const facts = [
+        ...dehydrateFact(subscriber),
+        ...dehydrateFact(creator),
+        ...Object.values(seeded).flatMap(v => dehydrateFact(v))
+    ];
+    // Dedupe by hash+type to avoid double-saving the shared predecessors.
+    const seenKeys = new Set<string>();
+    const uniqueFacts = facts.filter(f => {
+        const k = `${f.type}|${f.hash}`;
+        if (seenKeys.has(k)) return false;
+        seenKeys.add(k);
+        return true;
+    });
+    await storage.save(uniqueFacts.map(f => ({ fact: f, signatures: [] })));
+
+    const fork = new PassThroughFork(storage);
+    const observable = new ObservableSource(storage);
+    const network = new NetworkNoOp();
+    const factManager = new FactManager(fork, observable, storage, network, []);
+
+    const authorizationRules = new AuthorizationRules(model)
+        .no(User)
+        .any(Company)
+        .any(Office)
+        .any(Administrator);
+
+    const distributionRules = withDistributionRules
+        ? new DistributionRules([])
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ))
+        : null;
+
+    const authorization = new AuthorizationKeystore(
+        factManager, storage, keystore, authorizationRules, distributionRules);
+    return {
+        authorization,
+        subscriberFact,
+        seeded: seeded as T & { company: Company }
+    };
+}

--- a/test/http/anchorListenerSpec.ts
+++ b/test/http/anchorListenerSpec.ts
@@ -1,0 +1,117 @@
+import {
+    buildModel,
+    dehydrateFact,
+    FactManager,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    Specification,
+    User
+} from "jinaga";
+
+// Validates the same listener pattern HttpRouter.streamFeed uses to wake
+// subscriptions when an anchor (given) fact finally arrives at the
+// server. The pattern is: register a SpecificationListener on a spec
+// whose only given matches the anchor's type and whose matches array is
+// empty, then filter the projected results by the anchor hash.
+class Note {
+    public static Type = "anchor.Note" as const;
+    public type = Note.Type;
+    constructor(public author: User, public body: string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Note, m => m.predecessor("author", User))
+);
+
+function makeFactManager() {
+    const storage = new MemoryStore();
+    const fork = new PassThroughFork(storage);
+    const observable = new ObservableSource(storage);
+    const network = new NetworkNoOp();
+    const factManager = new FactManager(fork, observable, storage, network, []);
+    return { storage, factManager };
+}
+
+describe("anchor listener pattern", () => {
+    it("fires when a fact matching the anchor's (type, hash) is saved", async () => {
+        const { factManager } = makeFactManager();
+
+        const author = new User("anchor-author-key");
+        const authorRef = dehydrateFact(author)[0];
+
+        let firedFor: string | null = null;
+        const anchorSpec: Specification = {
+            given: [{ label: { name: "x", type: authorRef.type }, conditions: [] }],
+            matches: [],
+            projection: { type: "fact", label: "x" }
+        };
+        const listener = factManager.addSpecificationListener(anchorSpec, async (results) => {
+            for (const r of results) {
+                const ref = (r.tuple as any).x;
+                if (ref && ref.type === authorRef.type && ref.hash === authorRef.hash) {
+                    firedFor = ref.hash;
+                }
+            }
+        });
+
+        await factManager.save(dehydrateFact(author).map(f => ({ fact: f, signatures: [] })));
+
+        factManager.removeSpecificationListener(listener);
+        expect(firedFor).toBe(authorRef.hash);
+    });
+
+    it("does not fire for facts of an unrelated type", async () => {
+        const { factManager } = makeFactManager();
+
+        const author = new User("anchor-author-key");
+        const note = new Note(author, "hi");
+        const noteRef = dehydrateFact(note).find(f => f.type === Note.Type)!;
+
+        let fired = false;
+        const anchorSpec: Specification = {
+            given: [{ label: { name: "x", type: noteRef.type }, conditions: [] }],
+            matches: [],
+            projection: { type: "fact", label: "x" }
+        };
+        const listener = factManager.addSpecificationListener(anchorSpec, async () => {
+            fired = true;
+        });
+
+        // Save a fact of a different type only.
+        await factManager.save(dehydrateFact(author).map(f => ({ fact: f, signatures: [] })));
+
+        factManager.removeSpecificationListener(listener);
+        expect(fired).toBe(false);
+    });
+
+    it("does not fire for facts of the right type but a different hash", async () => {
+        const { factManager } = makeFactManager();
+
+        const expected = new User("expected-key");
+        const expectedRef = dehydrateFact(expected)[0];
+        const other = new User("other-key");
+
+        let matched = false;
+        const anchorSpec: Specification = {
+            given: [{ label: { name: "x", type: expectedRef.type }, conditions: [] }],
+            matches: [],
+            projection: { type: "fact", label: "x" }
+        };
+        const listener = factManager.addSpecificationListener(anchorSpec, async (results) => {
+            for (const r of results) {
+                const ref = (r.tuple as any).x;
+                if (ref && ref.type === expectedRef.type && ref.hash === expectedRef.hash) {
+                    matched = true;
+                }
+            }
+        });
+
+        await factManager.save(dehydrateFact(other).map(f => ({ fact: f, signatures: [] })));
+
+        factManager.removeSpecificationListener(listener);
+        expect(matched).toBe(false);
+    });
+});

--- a/test/http/lateAuthRecoverySpec.ts
+++ b/test/http/lateAuthRecoverySpec.ts
@@ -153,6 +153,67 @@ describe("late-auth subscription recovery", () => {
             .toContain(dehydrateFact(existingOffice).find(f => f.type === Office.Type)!.hash);
     });
 
+    it("does not let another authenticated user reuse an intersected feed hash", async () => {
+        const h = await makeHarness();
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+
+        // Alice (the subscriber) gets an authorizing Administrator and an
+        // existing Office. Without intersection she would already be
+        // authorized — but we want the *cached* intersected hash, so we
+        // build it before saving the Administrator.
+        const office = new Office(company, "HQ");
+        await h.factManager.save(dehydrateFact(office).map(f => ({ fact: f, signatures: [] })));
+
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    o: ${Office.Type} [\n` +
+            `        o->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => o`;
+
+        const aliceResponse = await (h.router as any).feeds(h.requestUser, input);
+        const intersectedHash: string = aliceResponse.feeds[0];
+
+        // Now grant Alice the Administrator role so the lifted spec
+        // actually produces rows when queried as Alice.
+        const admin = new Administrator(company, h.subscriber, new Date("2026-05-27"));
+        await h.factManager.save(dehydrateFact(admin).map(f => ({ fact: f, signatures: [] })));
+
+        // Alice can read her own intersected feed and sees the office.
+        const alicePage = await (h.router as any).feed(h.requestUser, { hash: intersectedHash }, {});
+        expect(alicePage.references.some((r: any) => r.type === Office.Type)).toBe(true);
+
+        // Mallory authenticates as a different user, then attempts to
+        // reuse the hash she obtained out of band. She must not be able
+        // to read Alice's data: the cached spec carries Alice's user
+        // fact, so allowing feedPreVerified would leak across users.
+        const malloryIdentity = { provider: "mock", id: "mallory" };
+        // Register Mallory with the keystore so getUserFact succeeds.
+        const malloryKeystore = (h.factManager as any); // unused; just to satisfy types
+        void malloryKeystore;
+        // The harness keystore is private; the lookup happens via the
+        // authorization keystore which the router holds. Re-using the
+        // harness keystore: get a fact for Mallory directly.
+        // (We rely on the keystore being shared with authorization.)
+        const malloryRequest: RequestUser = {
+            provider: malloryIdentity.provider,
+            id: malloryIdentity.id,
+            profile: {} as any
+        };
+
+        // First make Mallory exist in the keystore via a login-style call.
+        await (h.router as any).login(malloryRequest);
+
+        const malloryPage = await (h.router as any).feed(malloryRequest, { hash: intersectedHash }, {});
+        // The router must NOT have served Alice's data to Mallory. With
+        // the bind-to-owner fix in place, queryFeed routes Mallory
+        // through the normal distribution check, which fails, and the
+        // polling path returns an empty page.
+        expect(malloryPage.references.filter((r: any) => r.type === Office.Type)).toHaveLength(0);
+    });
+
     it("does not return a 403 from /feeds when no rule applies — connection stays available", async () => {
         const h = await makeHarness();
 

--- a/test/http/lateAuthRecoverySpec.ts
+++ b/test/http/lateAuthRecoverySpec.ts
@@ -1,0 +1,184 @@
+import {
+    AuthorizationRules,
+    buildModel,
+    dehydrateFact,
+    DistributionRules,
+    FactManager,
+    FeedCache,
+    FeedResponse,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    User
+} from "jinaga";
+
+import { AuthorizationKeystore } from "../../src/authorization/authorization-keystore";
+import { HttpRouter, RequestUser } from "../../src/http/router";
+import { Stream } from "../../src/http/stream";
+import { MemoryKeystore } from "../../src/memory/memory-keystore";
+
+// Mirrors the jinaga.js #130 contract: a client who cannot yet read a
+// feed must still be able to subscribe, receive an empty initial result,
+// and start receiving rows the moment an authorizing fact arrives — all
+// without the connection dying on a Forbidden.
+
+class Office {
+    public static Type = "late.Office" as const;
+    public type = Office.Type;
+    constructor(public company: Company, public name: string) { }
+}
+
+class Company {
+    public static Type = "late.Company" as const;
+    public type = Company.Type;
+    constructor(public creator: User, public identifier: string) { }
+}
+
+class Administrator {
+    public static Type = "late.Administrator" as const;
+    public type = Administrator.Type;
+    constructor(public company: Company, public user: User, public date: Date | string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Company, m => m.predecessor("creator", User))
+    .type(Office, m => m.predecessor("company", Company))
+    .type(Administrator, m => m
+        .predecessor("company", Company)
+        .predecessor("user", User))
+);
+
+const subscriberIdentity = { provider: "mock", id: "subscriber" };
+const creatorIdentity = { provider: "mock", id: "creator" };
+
+async function makeHarness() {
+    const storage = new MemoryStore();
+    const keystore = new MemoryKeystore();
+    const subscriberFact = await keystore.getOrCreateUserFact(subscriberIdentity);
+    const creatorFact = await keystore.getOrCreateUserFact(creatorIdentity);
+    const subscriber = new User(subscriberFact.fields.publicKey);
+    const creator = new User(creatorFact.fields.publicKey);
+
+    const fork = new PassThroughFork(storage);
+    const observable = new ObservableSource(storage);
+    const network = new NetworkNoOp();
+    const factManager = new FactManager(fork, observable, storage, network, []);
+
+    const authorizationRules = new AuthorizationRules(model)
+        .any(User)
+        .any(Company)
+        .any(Office)
+        .any(Administrator);
+    const distributionRules = new DistributionRules([])
+        .share(model.given(Company).match((c, facts) =>
+            facts.ofType(Office).join(o => o.company, c)
+        ))
+        .with(model.given(Company).match((c, facts) =>
+            facts.ofType(Administrator)
+                .join(a => a.company, c)
+                .selectMany(a => facts.ofType(User).join(u => u, a.user))
+        ));
+    const authorization = new AuthorizationKeystore(
+        factManager, storage, keystore, authorizationRules, distributionRules);
+    const feedCache = new FeedCache();
+    const router = new HttpRouter(factManager, authorization, feedCache, "*");
+
+    const requestUser: RequestUser = {
+        provider: subscriberIdentity.provider,
+        id: subscriberIdentity.id,
+        profile: {} as any
+    };
+    return { router, factManager, subscriber, creator, storage, requestUser };
+}
+
+async function drainMicrotasks() {
+    for (let i = 0; i < 8; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+describe("late-auth subscription recovery", () => {
+    it("subscribes empty when not authorized and activates when the auth fact arrives", async () => {
+        const h = await makeHarness();
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+        // Seed the Company and an existing Office. The subscriber is not
+        // yet an Administrator, so the rule denies them today.
+        const existingOffice = new Office(company, "HQ");
+        await h.factManager.save(dehydrateFact(existingOffice).map(f => ({ fact: f, signatures: [] })));
+
+        // Use the same given label name the rule's specs produce
+        // (`p1`, from `model.given(Company)`), so intersection can lift
+        // the rule's path conditions onto the subscription's given.
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    o: ${Office.Type} [\n` +
+            `        o->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => o`;
+
+        // POST /feeds must NOT throw Forbidden — the client is subscribing.
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, input);
+        expect(feedsResponse.feeds.length).toBeGreaterThan(0);
+        const feedHash: string = feedsResponse.feeds[0];
+
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+        expect(stream).not.toBeNull();
+
+        const received: FeedResponse[] = [];
+        stream.next(r => { received.push(r); });
+        await drainMicrotasks();
+
+        // Initial query is empty even though Office exists — the lifted
+        // auth condition (Administrator → subscriber) is not satisfied.
+        const initialOffices = received.flatMap(r => r.references)
+            .filter(r => r.type === Office.Type);
+        expect(initialOffices).toHaveLength(0);
+
+        // The authorizing fact arrives: subscriber is granted Admin.
+        const admin = new Administrator(company, h.subscriber, new Date("2026-05-27"));
+        await h.factManager.save(dehydrateFact(admin).map(f => ({ fact: f, signatures: [] })));
+        await drainMicrotasks();
+
+        stream.close();
+
+        // The pre-existing office surfaces as soon as the auth fact lands.
+        const officesAfterAuth = received.flatMap(r => r.references)
+            .filter(r => r.type === Office.Type);
+        expect(officesAfterAuth.map(r => r.hash))
+            .toContain(dehydrateFact(existingOffice).find(f => f.type === Office.Type)!.hash);
+    });
+
+    it("does not return a 403 from /feeds when no rule applies — connection stays available", async () => {
+        const h = await makeHarness();
+
+        // A spec the distribution rules do not cover at all. Step 1's
+        // strict semantics would have thrown Forbidden here, but the
+        // subscribe contract is to keep the connection live so the
+        // client can wait for results (e.g., a future rule change).
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+        await h.factManager.save(dehydrateFact(company).map(f => ({ fact: f, signatures: [] })));
+
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    a: ${Administrator.Type} [\n` +
+            `        a->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => a`;
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, input);
+        expect(feedsResponse.feeds.length).toBeGreaterThan(0);
+
+        // Polling the cached feed must also stay live (empty page, not 403).
+        const feedHash: string = feedsResponse.feeds[0];
+        const page = await (h.router as any).feed(h.requestUser, { hash: feedHash }, {});
+        expect(page).not.toBeNull();
+        expect(page.references).toEqual([]);
+    });
+});

--- a/test/http/streamFeedAnchorSpec.ts
+++ b/test/http/streamFeedAnchorSpec.ts
@@ -1,0 +1,169 @@
+import {
+    AuthorizationRules,
+    buildModel,
+    dehydrateFact,
+    FactManager,
+    FeedCache,
+    FeedResponse,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    User
+} from "jinaga";
+
+import { AuthorizationKeystore } from "../../src/authorization/authorization-keystore";
+import { HttpRouter, RequestUser } from "../../src/http/router";
+import { Stream } from "../../src/http/stream";
+import { MemoryKeystore } from "../../src/memory/memory-keystore";
+
+class Post {
+    public static Type = "stream.Post" as const;
+    public type = Post.Type;
+    constructor(public author: User, public body: string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Post, m => m.predecessor("author", User))
+);
+
+const userIdentity = { provider: "mock", id: "subscriber" };
+
+interface Harness {
+    router: HttpRouter;
+    factManager: FactManager;
+    storage: MemoryStore;
+    requestUser: RequestUser;
+    author: User;
+    authorRef: { type: string; hash: string };
+}
+
+async function makeHarness(): Promise<Harness> {
+    const storage = new MemoryStore();
+    const keystore = new MemoryKeystore();
+    const userFact = await keystore.getOrCreateUserFact(userIdentity);
+    const author = new User(userFact.fields.publicKey);
+    const authorRef = dehydrateFact(author)[0];
+
+    const fork = new PassThroughFork(storage);
+    const observable = new ObservableSource(storage);
+    const network = new NetworkNoOp();
+    const factManager = new FactManager(fork, observable, storage, network, []);
+
+    const authorizationRules = new AuthorizationRules(model)
+        .any(User)
+        .any(Post);
+    const authorization = new AuthorizationKeystore(
+        factManager, storage, keystore, authorizationRules, null);
+    const feedCache = new FeedCache();
+
+    const router = new HttpRouter(factManager, authorization, feedCache, "*");
+
+    return {
+        router,
+        factManager,
+        storage,
+        requestUser: { provider: userIdentity.provider, id: userIdentity.id, profile: {} as any },
+        author,
+        authorRef
+    };
+}
+
+async function waitForMicrotasks(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+describe("HttpRouter streamFeed anchor handling", () => {
+    it("delivers a post that joins to an anchor whose User fact arrives after subscribe", async () => {
+        const h = await makeHarness();
+
+        // Subscribe for posts by the author. The author fact's hash is
+        // referenced but not yet stored.
+        const input =
+            `let p: Jinaga.User = #${h.authorRef.hash}\n` +
+            `(p: Jinaga.User) {\n` +
+            `    post: stream.Post [\n` +
+            `        post->author: Jinaga.User = p\n` +
+            `    ]\n` +
+            `} => post`;
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, input);
+        expect(feedsResponse.feeds.length).toBeGreaterThan(0);
+        const feedHash: string = feedsResponse.feeds[0];
+
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+        expect(stream).not.toBeNull();
+
+        const received: FeedResponse[] = [];
+        stream.next(r => { received.push(r); });
+
+        await waitForMicrotasks();
+        expect(received).toEqual([]);
+
+        // Save the author + a post that joins to it.
+        const post = new Post(h.author, "first");
+        const envelopes = dehydrateFact(post).map(f => ({ fact: f, signatures: [] }));
+        await h.factManager.save(envelopes);
+
+        await waitForMicrotasks();
+        stream.close();
+
+        const allReferences = received.flatMap(r => r.references);
+        const postArrived = allReferences.some(r => r.type === Post.Type);
+        expect(postArrived).toBe(true);
+    });
+
+    it("re-runs the query when the anchor User fact arrives with descendants already in store", async () => {
+        const h = await makeHarness();
+
+        // Insert the post and its author directly through the underlying
+        // store so no observable notification fires for these. After
+        // subscribe, only the anchor-arrival path should trigger delivery.
+        const post = new Post(h.author, "preexisting");
+        const postFacts = dehydrateFact(post);
+        await h.storage.save(postFacts.map(f => ({ fact: f, signatures: [] })));
+
+        // Now subscribe.
+        const input =
+            `let p: Jinaga.User = #${h.authorRef.hash}\n` +
+            `(p: Jinaga.User) {\n` +
+            `    post: stream.Post [\n` +
+            `        post->author: Jinaga.User = p\n` +
+            `    ]\n` +
+            `} => post`;
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, input);
+        const feedHash: string = feedsResponse.feeds[0];
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+
+        const received: FeedResponse[] = [];
+        stream.next(r => { received.push(r); });
+        await waitForMicrotasks();
+
+        // The initial query should already have included the post (since
+        // it's in the store), so the subscription is "activated" via the
+        // initial fetch. Record what we have.
+        const beforeCount = received.flatMap(r => r.references)
+            .filter(r => r.type === Post.Type).length;
+
+        // Re-save the author through the FactManager so the anchor
+        // listener fires. The dedup at the store level returns no new
+        // envelopes, but the listener still has to behave gracefully.
+        await h.factManager.save(postFacts
+            .filter(f => f.type === "Jinaga.User")
+            .map(f => ({ fact: f, signatures: [] })));
+        await waitForMicrotasks();
+        stream.close();
+
+        // At minimum the post is visible after the anchor save and the
+        // stream does not error. With the initial fetch the post was
+        // already delivered; this guards against regressions where the
+        // anchor path tears down the stream.
+        expect(beforeCount).toBeGreaterThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
Includes jinaga.js#198/#200/#202 for the j.subscribe trust release.
DistributionEngine.canDistributeTo now falls back to canAuthorizeByComposition,
which transparently closes the negating-feed authorization (#196) and
multi-given distribution rule (#161) dimensions on the server.

Refs jinaga/jinaga-server#162