### PR TITLE
Persistent feed proxy with waitlist for race-free real-time streaming

### DIFF
--- a/docs/design/feeds-persistent-proxy-plan.md
+++ b/docs/design/feeds-persistent-proxy-plan.md
@@ -1,7 +1,17 @@
 # Feeds: Persistent Client Proxy with Waitlist
 Author: @michaellperry  
-Status: Draft  
+Status: Implemented  
 Scope: `/feeds/:hash` streaming path (`Accept: application/x-jinaga-feed-stream`)
+
+> **Implementation note.** The session described here lives in
+> `src/feeds/feed-stream-session.ts` (`FeedStreamSession`) and is wired into
+> the `/feeds/:hash` streaming handler in `src/http/router.ts`. Limits are
+> configurable through `JinagaServerConfig.feedStream`
+> (`FeedStreamSessionConfig`). Note that stores which return the full result
+> set with a non-advancing bookmark (e.g. the in-memory store) are treated as
+> exhausted after the first page, at which point the session emits SYNC.
+> Coverage: `test/feeds/feedStreamSessionSpec.ts` (unit) and
+> `test/http/feedStreamSessionIntegrationSpec.ts` (integration).
 
 ## Summary
 

--- a/src/feeds/feed-stream-session.ts
+++ b/src/feeds/feed-stream-session.ts
@@ -1,0 +1,374 @@
+import {
+    computeTupleSubsetHash,
+    FactManager,
+    FactReference,
+    FeedObject,
+    FeedResponse,
+    invertSpecification,
+    ProjectedResult,
+    Specification,
+    SpecificationListener,
+    Trace
+} from "jinaga";
+import { FeedResult } from "../authorization/authorization-keystore";
+import { Stream } from "../http/stream";
+
+/**
+ * A function that queries the feed for the next page of tuples, starting
+ * from the supplied bookmark. Returns a {@link FeedResult} so the session
+ * can keep the stream alive when distribution is denied at query time.
+ */
+export type FeedQuery = (bookmark: string) => Promise<FeedResult>;
+
+export interface FeedStreamSessionConfig {
+    /** Maximum number of pages to stream before giving up (infinite-loop guard). */
+    maxInitialPages: number;
+    /** Maximum number of references the waitlist may hold before the stream is dropped. */
+    waitlistCap: number;
+    /** Insert a small delay every N pages to avoid overwhelming the database. */
+    pageDelayEvery: number;
+    /** Length of the delay inserted by {@link pageDelayEvery}, in milliseconds. */
+    pageDelayMs: number;
+}
+
+export const defaultFeedStreamSessionConfig: FeedStreamSessionConfig = {
+    maxInitialPages: 1000,
+    waitlistCap: 50000,
+    pageDelayEvery: 10,
+    pageDelayMs: 10
+};
+
+interface FeedStreamSessionTelemetry {
+    initialPages: number;
+    referencesStreamed: number;
+    cycles: number;
+    syncFrames: number;
+    waitlistRestarts: number;
+    waitlistHighWater: number;
+}
+
+function referenceKey(reference: FactReference): string {
+    return `${reference.type}:${reference.hash}`;
+}
+
+function dedupeReferences(references: FactReference[]): FactReference[] {
+    return references.filter((value, index, self) =>
+        self.findIndex(other => other.hash === value.hash && other.type === value.type) === index);
+}
+
+/**
+ * Per-connection proxy for a streaming feed subscription.
+ *
+ * The session funnels every fetch and stream operation through a single
+ * "query cycle" driven by the current bookmark. Inverse observers never
+ * fetch or stream directly; they only enqueue fact references onto a
+ * waitlist and wake the cycle. This serialization removes the race between
+ * listener callbacks and bookmark mutation, guarantees tuple completeness,
+ * and ensures no update is lost when facts arrive between pages.
+ *
+ * See docs/design/feeds-persistent-proxy-plan.md for the full design.
+ */
+export class FeedStreamSession {
+    private bookmark: string;
+    private readonly config: FeedStreamSessionConfig;
+
+    // Waitlist of fact references surfaced by inverse observers, keyed by
+    // "{type}:{hash}" so duplicates collapse. A reference stays on the
+    // waitlist until the tuple that contains it is streamed, preserving
+    // tuple completeness.
+    private readonly waitlist = new Map<string, FactReference>();
+
+    // Single-cycle execution guard. Only one runCycle() executes at a time;
+    // wake-ups that arrive while a cycle runs set needsCycle so the loop
+    // re-evaluates before returning.
+    private activeCycle = false;
+    private needsCycle = false;
+    private shuttingDown = false;
+
+    private listeners: SpecificationListener[] = [];
+    private readonly telemetry: FeedStreamSessionTelemetry = {
+        initialPages: 0,
+        referencesStreamed: 0,
+        cycles: 0,
+        syncFrames: 0,
+        waitlistRestarts: 0,
+        waitlistHighWater: 0
+    };
+
+    constructor(
+        private readonly query: FeedQuery,
+        private readonly factManager: FactManager,
+        private readonly feedDefinition: FeedObject,
+        private readonly startReferences: FactReference[],
+        private readonly givenHash: string,
+        private readonly stream: Stream<FeedResponse>,
+        initialBookmark: string,
+        private readonly connectionId: string = Math.random().toString(36).substring(2, 10),
+        config: Partial<FeedStreamSessionConfig> = {}
+    ) {
+        this.bookmark = initialBookmark;
+        this.config = { ...defaultFeedStreamSessionConfig, ...config };
+    }
+
+    /** Current number of references on the waitlist (observability/testing). */
+    get waitlistSize(): number {
+        return this.waitlist.size;
+    }
+
+    /**
+     * Register inverse and anchor observers, then kick off the initial
+     * paginated backfill. Resolves once the observers are registered; the
+     * cycle continues to run asynchronously, feeding the stream.
+     */
+    start(): void {
+        this.registerInverseListeners();
+        this.registerAnchorListeners();
+        // Kick off the initial backfill. Errors are isolated so a failed
+        // cycle never rejects the caller's setup path.
+        this.wake();
+    }
+
+    /**
+     * Tear down all observers and prevent any further cycles. Idempotent.
+     */
+    dispose(): void {
+        if (this.shuttingDown) {
+            return;
+        }
+        this.shuttingDown = true;
+        for (const listener of this.listeners) {
+            try {
+                this.factManager.removeSpecificationListener(listener);
+            } catch (error) {
+                Trace.error(error);
+            }
+        }
+        this.listeners = [];
+        Trace.metric(`Feed stream session ${this.connectionId} closed`, {
+            initialPages: this.telemetry.initialPages,
+            referencesStreamed: this.telemetry.referencesStreamed,
+            cycles: this.telemetry.cycles,
+            syncFrames: this.telemetry.syncFrames,
+            waitlistRestarts: this.telemetry.waitlistRestarts,
+            waitlistHighWater: this.telemetry.waitlistHighWater
+        });
+    }
+
+    /**
+     * Add fact references to the waitlist and wake the cycle. Called by the
+     * inverse observers; never fetches or streams directly.
+     */
+    onInverseMatch(references: FactReference[]): void {
+        if (this.shuttingDown) {
+            return;
+        }
+        for (const reference of references) {
+            this.waitlist.set(referenceKey(reference), reference);
+        }
+        if (this.waitlist.size > this.telemetry.waitlistHighWater) {
+            this.telemetry.waitlistHighWater = this.waitlist.size;
+        }
+        if (this.waitlist.size > this.config.waitlistCap) {
+            Trace.warn(`Feed stream session ${this.connectionId} waitlist exceeded cap ` +
+                `(${this.waitlist.size} > ${this.config.waitlistCap}); closing stream.`);
+            this.dispose();
+            this.stream.close();
+            return;
+        }
+        this.wake();
+    }
+
+    /**
+     * Start a cycle if one is not already running. If a cycle is active,
+     * mark that another pass is needed once it completes.
+     */
+    private wake(): void {
+        if (this.shuttingDown) {
+            return;
+        }
+        if (this.activeCycle) {
+            this.needsCycle = true;
+            return;
+        }
+        // Run the cycle without awaiting; isolate failures.
+        void this.runCycle().catch(error => Trace.error(error));
+    }
+
+    /**
+     * The single serialized query cycle. Pages through the feed until both
+     * the query returns no tuples and the waitlist is empty, then emits a
+     * SYNC frame. Guarded by activeCycle so no two cycles run concurrently.
+     */
+    private async runCycle(): Promise<void> {
+        if (this.activeCycle) {
+            this.needsCycle = true;
+            return;
+        }
+        this.activeCycle = true;
+        this.telemetry.cycles++;
+        try {
+            let pagesThisCycle = 0;
+            let keepGoing = true;
+            while (keepGoing && !this.shuttingDown) {
+                this.needsCycle = false;
+
+                const result = await this.query(this.bookmark);
+                if (this.shuttingDown) {
+                    break;
+                }
+                if (result.type === "denied") {
+                    // Distribution denied at query time. Keep the stream
+                    // alive (an authorizing fact may arrive later and wake a
+                    // new cycle) but stop the loop without emitting SYNC,
+                    // since we are not actually caught up.
+                    Trace.info(`Feed stream session ${this.connectionId} query denied: ${result.reason}`);
+                    break;
+                }
+
+                const feed = result.feed;
+                if (feed.tuples.length > 0) {
+                    const references = dedupeReferences(feed.tuples.flatMap(t => t.facts));
+                    this.streamPage(references, feed.bookmark);
+                    this.removeFromWaitlist(references);
+                    pagesThisCycle++;
+                    this.telemetry.initialPages++;
+
+                    if (feed.bookmark === this.bookmark) {
+                        // The store returned results but the bookmark did not
+                        // advance, meaning it cannot paginate further (e.g.
+                        // MemoryStore returns the full result set on every
+                        // call). Everything available has been delivered, so
+                        // treat this as caught-up: drop any waitlist entries
+                        // that the full page did not satisfy and emit SYNC.
+                        // Re-querying with the same bookmark would loop
+                        // forever re-delivering identical tuples.
+                        this.waitlist.clear();
+                        this.streamSync();
+                        keepGoing = false;
+                    }
+                    else {
+                        this.bookmark = feed.bookmark;
+                        if (pagesThisCycle >= this.config.maxInitialPages) {
+                            Trace.warn(`Feed stream session ${this.connectionId} hit max page limit ` +
+                                `(${this.config.maxInitialPages}); ending cycle.`);
+                            break;
+                        }
+                        if (this.config.pageDelayEvery > 0 &&
+                            pagesThisCycle % this.config.pageDelayEvery === 0) {
+                            await this.delay(this.config.pageDelayMs);
+                        }
+                        // Continue paging.
+                    }
+                }
+                else {
+                    // No tuples this query.
+                    if (this.waitlist.size === 0) {
+                        this.streamSync();
+                        keepGoing = false;
+                    }
+                    else if (this.needsCycle) {
+                        // A wake arrived during this query; re-run so the
+                        // just-arrived facts get a chance to produce tuples.
+                        this.telemetry.waitlistRestarts++;
+                    }
+                    else {
+                        // The waitlist holds references whose tuples are not
+                        // completable at the current bookmark (e.g. a missing
+                        // predecessor). They cannot produce a tuple now, so
+                        // drop them to avoid spinning and emit SYNC. A later
+                        // trigger will re-add them once they are completable.
+                        this.waitlist.clear();
+                        this.streamSync();
+                        keepGoing = false;
+                    }
+                }
+            }
+        } finally {
+            this.activeCycle = false;
+            // A wake that arrived as the loop exited must start a fresh
+            // cycle, since this one already cleared activeCycle.
+            if (this.needsCycle && !this.shuttingDown) {
+                this.needsCycle = false;
+                this.wake();
+            }
+        }
+    }
+
+    private streamPage(references: FactReference[], bookmark: string): void {
+        const response: FeedResponse = { references, bookmark };
+        this.telemetry.referencesStreamed += references.length;
+        this.stream.feed(response);
+    }
+
+    private streamSync(): void {
+        const response: FeedResponse = { references: [], bookmark: this.bookmark };
+        this.telemetry.syncFrames++;
+        this.stream.feed(response);
+    }
+
+    private removeFromWaitlist(references: FactReference[]): void {
+        for (const reference of references) {
+            this.waitlist.delete(referenceKey(reference));
+        }
+    }
+
+    private delay(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    private registerInverseListeners(): void {
+        const inverses = invertSpecification(this.feedDefinition.feed);
+        for (const inverse of inverses) {
+            const listener = this.factManager.addSpecificationListener(
+                inverse.inverseSpecification,
+                async (results: ProjectedResult[]) => {
+                    if (this.shuttingDown) {
+                        return;
+                    }
+                    // Only enqueue results whose given subset matches this
+                    // subscription's given.
+                    const matching = results.filter(pr =>
+                        this.givenHash === computeTupleSubsetHash(pr.tuple, inverse.givenSubset));
+                    if (matching.length === 0) {
+                        return;
+                    }
+                    const references = dedupeReferences(
+                        matching.flatMap(pr => Object.values(pr.tuple)));
+                    this.onInverseMatch(references);
+                });
+            this.listeners.push(listener);
+        }
+    }
+
+    private registerAnchorListeners(): void {
+        // Anchor listeners (jinaga.js#129): the inverse-listener path only
+        // fires when a descendant of the given arrives. If the given fact
+        // itself isn't yet in the store when the client subscribes, no
+        // inverse can deliver results until the given is recorded. Register
+        // a listener per unique anchor that wakes the cycle the moment a
+        // saved fact matches the anchor's (type, hash). The anchor itself is
+        // not added to the waitlist; the query will surface its descendants.
+        const uniqueAnchors = this.startReferences.filter((s, i, arr) =>
+            arr.findIndex(other => other.type === s.type && other.hash === s.hash) === i);
+        for (const anchor of uniqueAnchors) {
+            const anchorSpec: Specification = {
+                given: [{ label: { name: "x", type: anchor.type }, conditions: [] }],
+                matches: [],
+                projection: { type: "fact", label: "x" }
+            };
+            const listener = this.factManager.addSpecificationListener(anchorSpec, async (results: ProjectedResult[]) => {
+                if (this.shuttingDown) {
+                    return;
+                }
+                const matched = results.some(pr => {
+                    const ref = pr.tuple && (pr.tuple as any).x;
+                    return ref && ref.type === anchor.type && ref.hash === anchor.hash;
+                });
+                if (matched) {
+                    this.wake();
+                }
+            });
+            this.listeners.push(listener);
+        }
+    }
+}

--- a/src/feeds/feed-stream-session.ts
+++ b/src/feeds/feed-stream-session.ts
@@ -52,8 +52,16 @@ function referenceKey(reference: FactReference): string {
 }
 
 function dedupeReferences(references: FactReference[]): FactReference[] {
-    return references.filter((value, index, self) =>
-        self.findIndex(other => other.hash === value.hash && other.type === value.type) === index);
+    const seen = new Set<string>();
+    const result: FactReference[] = [];
+    for (const reference of references) {
+        const key = referenceKey(reference);
+        if (!seen.has(key)) {
+            seen.add(key);
+            result.push(reference);
+        }
+    }
+    return result;
 }
 
 /**
@@ -144,7 +152,11 @@ export class FeedStreamSession {
             }
         }
         this.listeners = [];
-        Trace.metric(`Feed stream session ${this.connectionId} closed`, {
+        // Use a stable metric name so a metrics backend does not see
+        // unbounded cardinality from per-connection IDs. The connection ID
+        // is logged separately for correlation.
+        Trace.info(`Feed stream session ${this.connectionId} closed`);
+        Trace.metric("Feed stream session closed", {
             initialPages: this.telemetry.initialPages,
             referencesStreamed: this.telemetry.referencesStreamed,
             cycles: this.telemetry.cycles,

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -3,14 +3,12 @@ import {
     Authorization,
     buildFeeds,
     computeObjectHash,
-    computeTupleSubsetHash,
     Declaration,
     FactEnvelope,
     FactManager,
     FactRecord,
     FactReference,
     FeedCache,
-    FeedObject,
     FeedResponse,
     FeedsResponse,
     Forbidden,
@@ -18,7 +16,6 @@ import {
     GraphSerializer,
     GraphSource,
     Invalid,
-    invertSpecification,
     LoadMessage,
     LoadResponse,
     parseLoadMessage,
@@ -33,6 +30,7 @@ import {
     verifyEnvelopes
 } from "jinaga";
 import { DistributionIntersectionBranch, FeedResult, SubscriptionAuthorizer } from "../authorization/authorization-keystore";
+import { FeedStreamSession, FeedStreamSessionConfig } from "../feeds/feed-stream-session";
 import { CsvMetadata } from "./csv-metadata";
 import { validateSpecificationForCsv } from "./csv-validator";
 import { createLineReader } from "./line-reader";
@@ -385,7 +383,8 @@ export class HttpRouter {
         private factManager: FactManager,
         private authorization: Authorization & SubscriptionAuthorizer,
         private feedCache: FeedCache,
-        private allowedOrigin: string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void)
+        private allowedOrigin: string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void),
+        private feedStreamConfig: Partial<FeedStreamSessionConfig> = {}
     ) {
         const router = Router();
         const applyAllowOrigin = this.applyAllowOrigin.bind(this);
@@ -698,304 +697,47 @@ export class HttpRouter {
 
     private async streamFeed(user: RequestUser | null, params: { [key: string]: string }, query: qs.ParsedQs): Promise<Stream<FeedResponse> | null> {
         const connectionId = Math.random().toString(36).substring(2, 10);
-        const startTime = Date.now();
-        
-        console.log(`[StreamFeed:${connectionId}] NEW CONNECTION - User: ${user?.id || 'anonymous'}, Hash: ${params["hash"]}`);
-        
+
         const feedHash = params["hash"];
         if (!feedHash) {
-            console.log(`[StreamFeed:${connectionId}] No feed hash provided`);
             return null;
         }
 
         const feedDefinition = await this.feedCache.getFeed(feedHash);
         if (!feedDefinition) {
-            console.log(`[StreamFeed:${connectionId}] Feed definition not found for hash: ${feedHash}`);
             return null;
         }
 
-        let bookmark = query["b"] as string ?? "";
-        console.log(`[StreamFeed:${connectionId}] Initial bookmark: ${bookmark || 'empty'}`);
+        const bookmark = query["b"] as string ?? "";
 
         const userIdentity = serializeUserIdentity(user);
         const start = feedDefinition.feed.given.map(g => feedDefinition.namedStart[g.label.name]);
         const givenHash = computeObjectHash(feedDefinition.namedStart);
 
-        console.log(`[StreamFeed:${connectionId}] Feed setup - Given hash: ${givenHash.substring(0, 8)}..., Start facts: ${start.length}`);
-
         const stream = new Stream<FeedResponse>();
-        
-        try {
-            // Continuous initial query until exhausted
-            console.log(`[StreamFeed:${connectionId}] Starting initial data streaming...`);
-            const initialStart = Date.now();
-            bookmark = await this.streamAllInitialResults(feedHash, userIdentity, feedDefinition, start, bookmark, stream);
-            const initialDuration = Date.now() - initialStart;
-            console.log(`[StreamFeed:${connectionId}] Initial data streaming complete - Duration: ${initialDuration}ms, Final bookmark: ${bookmark || 'empty'}`);
-            
-            // Set up real-time listeners after initial data is complete
-            console.log(`[StreamFeed:${connectionId}] Setting up real-time listeners...`);
-            const inverses = invertSpecification(feedDefinition.feed);
-            console.log(`[StreamFeed:${connectionId}] Created ${inverses.length} inverse specifications`);
-            
-            const listeners = inverses.map((inverse, index) => {
-                console.log(`[StreamFeed:${connectionId}] Adding listener ${index + 1}/${inverses.length}`);
-                
-                return this.factManager.addSpecificationListener(
-                    inverse.inverseSpecification,
-                    async (results) => {
-                        const eventStart = Date.now();
-                        console.log(`[StreamFeed:${connectionId}] EVENT RECEIVED - Listener ${index + 1}, Results: ${results.length}`);
-                        
-                        try {
-                            // Filter out results that do not match the given.
-                            const matchingResults = results.filter(pr =>
-                                givenHash === computeTupleSubsetHash(pr.tuple, inverse.givenSubset));
-                            
-                            console.log(`[StreamFeed:${connectionId}] Filtered results - Matching: ${matchingResults.length}/${results.length}`);
-                            
-                            if (matchingResults.length != 0) {
-                                console.log(`[StreamFeed:${connectionId}] Processing matching results...`);
-                                const responseStart = Date.now();
-                                bookmark = await this.streamFeedResponse(feedHash, userIdentity, feedDefinition, start, bookmark, stream, true);
-                                const responseDuration = Date.now() - responseStart;
-                                console.log(`[StreamFeed:${connectionId}] Feed response sent - Duration: ${responseDuration}ms, New bookmark: ${bookmark || 'empty'}`);
-                            } else {
-                                console.log(`[StreamFeed:${connectionId}] No matching results - skipping response`);
-                            }
-                        } catch (error) {
-                            console.error(`[StreamFeed:${connectionId}] ERROR processing event: ${error}`);
-                        }
-                        
-                        const eventDuration = Date.now() - eventStart;
-                        if (eventDuration > 100) {
-                            console.warn(`[StreamFeed:${connectionId}] SLOW event processing - Duration: ${eventDuration}ms`);
-                        }
-                    }
-                );
-            });
-            
-            console.log(`[StreamFeed:${connectionId}] All listeners registered - Count: ${listeners.length}`);
 
-            // Anchor listeners (jinaga.js#129): the inverse-listener path
-            // above only fires when a descendant of the given arrives. If
-            // the given fact itself isn't yet in the store when the client
-            // subscribes, neither the initial query nor any later inverse
-            // can deliver results until the given is recorded — and the
-            // given fact has no descendants whose save would re-trigger the
-            // inverse with the matching givenHash. Register a listener per
-            // unique anchor that re-runs streamFeedResponse the moment a
-            // saved fact matches the anchor's (type, hash).
-            const uniqueAnchors = start.filter((s, i, arr) =>
-                arr.findIndex(other => other.type === s.type && other.hash === s.hash) === i);
-            console.log(`[StreamFeed:${connectionId}] Registering ${uniqueAnchors.length} anchor listener(s)`);
-            const anchorListeners = uniqueAnchors.map(anchor => {
-                const anchorSpec: Specification = {
-                    given: [{ label: { name: "x", type: anchor.type }, conditions: [] }],
-                    matches: [],
-                    projection: { type: "fact", label: "x" }
-                };
-                return this.factManager.addSpecificationListener(anchorSpec, async (results) => {
-                    try {
-                        const matched = results.some(pr => {
-                            const ref = pr.tuple && (pr.tuple as any).x;
-                            return ref && ref.type === anchor.type && ref.hash === anchor.hash;
-                        });
-                        if (matched) {
-                            console.log(`[StreamFeed:${connectionId}] Anchor fact arrived - Type: ${anchor.type}, Hash: ${anchor.hash.substring(0, 8)}...`);
-                            bookmark = await this.streamFeedResponse(feedHash, userIdentity, feedDefinition, start, bookmark, stream, true);
-                        }
-                    } catch (error) {
-                        console.error(`[StreamFeed:${connectionId}] ERROR in anchor listener: ${error}`);
-                    }
-                });
-            });
-
-            stream.done(() => {
-                const cleanupStart = Date.now();
-                console.log(`[StreamFeed:${connectionId}] CLEANUP STARTED - Removing ${listeners.length + anchorListeners.length} listener(s)`);
-
-                for (let i = 0; i < listeners.length; i++) {
-                    try {
-                        this.factManager.removeSpecificationListener(listeners[i]);
-                        console.log(`[StreamFeed:${connectionId}] Removed listener ${i + 1}/${listeners.length}`);
-                    } catch (error) {
-                        console.error(`[StreamFeed:${connectionId}] ERROR removing listener ${i + 1}: ${error}`);
-                    }
-                }
-                for (let i = 0; i < anchorListeners.length; i++) {
-                    try {
-                        this.factManager.removeSpecificationListener(anchorListeners[i]);
-                    } catch (error) {
-                        console.error(`[StreamFeed:${connectionId}] ERROR removing anchor listener ${i + 1}: ${error}`);
-                    }
-                }
-
-                const cleanupDuration = Date.now() - cleanupStart;
-                const totalDuration = Date.now() - startTime;
-                console.log(`[StreamFeed:${connectionId}] CLEANUP COMPLETE - Cleanup duration: ${cleanupDuration}ms, Total connection duration: ${totalDuration}ms`);
-            });
-            
-            const setupDuration = Date.now() - startTime;
-            console.log(`[StreamFeed:${connectionId}] Stream setup complete - Duration: ${setupDuration}ms`);
-            
-            return stream;
-            
-        } catch (error) {
-            console.error(`[StreamFeed:${connectionId}] ERROR during setup: ${error}`);
-            throw error;
-        }
-    }
-
-    private async streamAllInitialResults(
-        feedHash: string,
-        userIdentity: UserIdentity | null,
-        feedDefinition: FeedObject,
-        start: FactReference[],
-        initialBookmark: string,
-        stream: Stream<FeedResponse>
-    ): Promise<string> {
-        const streamId = Math.random().toString(36).substring(2, 8);
-        console.log(`[InitialResults:${streamId}] Starting initial data fetch - Bookmark: ${initialBookmark || 'empty'}`);
-        
-        let bookmark = initialBookmark;
-        let hasMoreResults = true;
-        let pageCount = 0;
-        let totalReferences = 0;
-        const maxPages = 1000; // Safety limit to prevent infinite loops
-        const startTime = Date.now();
-        
-        while (hasMoreResults && pageCount < maxPages) {
-            const pageStart = Date.now();
-            console.log(`[InitialResults:${streamId}] Fetching page ${pageCount + 1} - Bookmark: ${bookmark || 'empty'}`);
-
-            const queryResult = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
-            if (queryResult.type === "denied") {
-                // The subscription has already been accepted; tearing
-                // down the stream on a distribution failure would force
-                // the client to re-subscribe just to keep waiting.
-                // Treat as empty and let the listener path re-evaluate
-                // when an authorizing fact arrives.
-                console.log(`[InitialResults:${streamId}] Distribution failed (${queryResult.reason}) - serving empty and keeping stream live`);
-                return bookmark;
-            }
-            const results = queryResult.feed;
-            const fetchDuration = Date.now() - pageStart;
-
-            console.log(`[InitialResults:${streamId}] Page ${pageCount + 1} fetched - Tuples: ${results.tuples.length}, Duration: ${fetchDuration}ms`);
-            
-            // Check if we got results
-            if (results.tuples.length === 0) {
-                console.log(`[InitialResults:${streamId}] No more results - ending pagination`);
-                hasMoreResults = false;
-                break;
-            }
-            
-            // Process and send results
-            const processStart = Date.now();
-            const references = results.tuples.flatMap(t => t.facts).filter((value, index, self) =>
-                self.findIndex(f => f.hash === value.hash && f.type === value.type) === index
-            );
-            const processDuration = Date.now() - processStart;
-            
-            console.log(`[InitialResults:${streamId}] Page ${pageCount + 1} processed - References: ${references.length}, Process duration: ${processDuration}ms`);
-            
-            if (references.length > 0) {
-                const response: FeedResponse = {
-                    references,
-                    bookmark: results.bookmark
-                };
-                
-                const feedStart = Date.now();
-                stream.feed(response);
-                const feedDuration = Date.now() - feedStart;
-                
-                totalReferences += references.length;
-                console.log(`[InitialResults:${streamId}] Page ${pageCount + 1} sent to stream - Feed duration: ${feedDuration}ms`);
-            }
-            
-            // Update bookmark for next iteration
-            const newBookmark = results.bookmark;
-            if (newBookmark === bookmark) {
-                console.log(`[InitialResults:${streamId}] Bookmark unchanged - ending pagination`);
-                hasMoreResults = false;
-            } else {
-                bookmark = newBookmark;
-            }
-            
-            // Check if we got fewer results than the page size (indicates end)
-            if (results.tuples.length < 100) {
-                console.log(`[InitialResults:${streamId}] Partial page received (${results.tuples.length} < 100) - ending pagination`);
-                hasMoreResults = false;
-            }
-            
-            pageCount++;
-            
-            // Add small delay to prevent overwhelming the database
-            if (hasMoreResults && pageCount % 10 === 0) {
-                console.log(`[InitialResults:${streamId}] Adding delay after ${pageCount} pages`);
-                await new Promise(resolve => setTimeout(resolve, 10));
-            }
-        }
-        
-        const totalDuration = Date.now() - startTime;
-        console.log(`[InitialResults:${streamId}] Initial data streaming complete - Pages: ${pageCount}, Total references: ${totalReferences}, Duration: ${totalDuration}ms, Final bookmark: ${bookmark || 'empty'}`);
-        
-        if (pageCount >= maxPages) {
-            console.warn(`[InitialResults:${streamId}] Hit maximum page limit (${maxPages}) - possible infinite loop`);
-        }
-        
-        return bookmark;
-    }
-
-    private async streamFeedResponse(feedHash: string, userIdentity: UserIdentity | null, feedDefinition: FeedObject, start: FactReference[], bookmark: string, stream: Stream<FeedResponse>, skipIfEmpty = false): Promise<string> {
-        const responseId = Math.random().toString(36).substring(2, 6);
-        const startTime = Date.now();
-        
-        console.log(`[FeedResponse:${responseId}] Starting feed response - Bookmark: ${bookmark || 'empty'}, Skip if empty: ${skipIfEmpty}`);
-        
-        const feedStart = Date.now();
-        const queryResult = await this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, bookmark);
-        if (queryResult.type === "denied") {
-            // The subscription stays live across distribution failures
-            // so the inverse / anchor listeners can deliver results
-            // once the authorizing fact arrives.
-            console.log(`[FeedResponse:${responseId}] Distribution failed (${queryResult.reason}) - keeping stream live`);
-            return bookmark;
-        }
-        const results = queryResult.feed;
-        const feedDuration = Date.now() - feedStart;
-
-        console.log(`[FeedResponse:${responseId}] Authorization feed complete - Tuples: ${results.tuples.length}, Duration: ${feedDuration}ms`);
-        
-        // Return distinct fact references from all the tuples.
-        const processStart = Date.now();
-        const references = results.tuples.flatMap(t => t.facts).filter((value, index, self) =>
-            self.findIndex(f => f.hash === value.hash && f.type === value.type) === index
+        // The session serializes every fetch and stream operation through a
+        // single bookmark-driven query cycle. Inverse and anchor observers
+        // only enqueue references onto a waitlist and wake the cycle; they
+        // never fetch or stream directly. This removes the race between
+        // listener callbacks and bookmark mutation, guarantees tuple
+        // completeness, and ensures no update is lost between pages.
+        const session = new FeedStreamSession(
+            (b: string) => this.queryFeed(feedHash, userIdentity, feedDefinition.feed, start, b),
+            this.factManager,
+            feedDefinition,
+            start,
+            givenHash,
+            stream,
+            bookmark,
+            connectionId,
+            this.feedStreamConfig
         );
-        const processDuration = Date.now() - processStart;
-        
-        console.log(`[FeedResponse:${responseId}] References processed - Count: ${references.length}, Duration: ${processDuration}ms`);
-        
-        if (!skipIfEmpty || references.length > 0) {
-            const response: FeedResponse = {
-                references,
-                bookmark: results.bookmark
-            };
-            
-            const streamStart = Date.now();
-            stream.feed(response);
-            const streamDuration = Date.now() - streamStart;
-            
-            console.log(`[FeedResponse:${responseId}] Response sent to stream - Duration: ${streamDuration}ms`);
-        } else {
-            console.log(`[FeedResponse:${responseId}] Skipping empty response`);
-        }
-        
-        const totalDuration = Date.now() - startTime;
-        console.log(`[FeedResponse:${responseId}] Feed response complete - New bookmark: ${results.bookmark || 'empty'}, Total duration: ${totalDuration}ms`);
-        
-        return results.bookmark;
+
+        stream.done(() => session.dispose());
+        session.start();
+
+        return stream;
     }
 
     private async getKnownFacts(user: RequestUser | null): Promise<Declaration> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { AuthenticationDevice } from "./authentication/authentication-device";
 export { AuthenticationSession } from "./authentication/authentication-session";
 export { AuthorizationKeystore } from "./authorization/authorization-keystore";
 export { DistributedFactCache } from "./authorization/distributed-fact-cache";
+export { FeedStreamSession, FeedStreamSessionConfig, defaultFeedStreamSessionConfig } from "./feeds/feed-stream-session";
 export { createLineReader } from "./http/line-reader";
 export { HttpRouter, RequestUser } from "./http/router";
 export { Stream } from "./http/stream";

--- a/src/jinaga-server.ts
+++ b/src/jinaga-server.ts
@@ -37,6 +37,7 @@ import { Pool } from "pg";
 import { AuthenticationDevice } from "./authentication/authentication-device";
 import { AuthenticationSession } from "./authentication/authentication-session";
 import { AuthorizationKeystore, DistributionBranchesResult, FeedResult, SubscriptionAuthorizer } from "./authorization/authorization-keystore";
+import { FeedStreamSessionConfig } from "./feeds/feed-stream-session";
 import { HttpRouter, RequestUser } from "./http/router";
 import { Keystore } from "./keystore";
 import { PostgresKeystore } from "./postgres/postgres-keystore";
@@ -56,7 +57,13 @@ export type JinagaServerConfig = {
     authorization?: (a: AuthorizationRules) => AuthorizationRules,
     distribution?: (d: DistributionRules) => DistributionRules,
     purgeConditions?: (p: PurgeConditions) => PurgeConditions,
-    origin?: string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void)
+    origin?: string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void),
+    /**
+     * Tuning for the per-connection feed streaming session
+     * (/feeds/:hash with Accept: application/x-jinaga-feed-stream).
+     * See FeedStreamSessionConfig for the available limits and defaults.
+     */
+    feedStream?: Partial<FeedStreamSessionConfig>
 };
 
 export type JinagaServerInstance = {
@@ -91,7 +98,7 @@ export class JinagaServer {
         const purgeConditions = createPurgeConditions(config);
         const factManager = new FactManager(fork, source, store, network, purgeConditions);
         const authorization = createAuthorization(authorizationRules, distributionRules, factManager, store, keystore);
-        const router = new HttpRouter(factManager, authorization, feedCache, config.origin || '*');
+        const router = new HttpRouter(factManager, authorization, feedCache, config.origin || '*', config.feedStream || {});
         const j: Jinaga = new Jinaga(authentication, factManager, syncStatusNotifier);
 
         async function close() {

--- a/test/feeds/feedStreamSessionRegressionSpec.ts
+++ b/test/feeds/feedStreamSessionRegressionSpec.ts
@@ -1,0 +1,227 @@
+import {
+    buildFeeds,
+    computeObjectHash,
+    FactFeed,
+    FactManager,
+    FactReference,
+    FeedObject,
+    FeedResponse,
+    ProjectedResult,
+    ReferencesByName,
+    Specification,
+    SpecificationListener,
+    SpecificationParser
+} from "jinaga";
+
+import { FeedResult } from "../../src/authorization/authorization-keystore";
+import { FeedStreamSession } from "../../src/feeds/feed-stream-session";
+import { Stream } from "../../src/http/stream";
+
+// Regression coverage for scenarios the primary unit spec does not exercise:
+// a store whose bookmark actually advances across a real-time update, recovery
+// of a fact that was dropped from the waitlist as "stale", and disposal while
+// a query is in flight. These lock down the core streaming guarantees against
+// future changes to the cycle/waitlist logic.
+
+function buildFeedDefinition(): { feedDefinition: FeedObject; givenHash: string } {
+    const anchorHash = "anchorhash000000000000000000000000000000000000";
+    const input =
+        `let p: Jinaga.User = #${anchorHash}\n` +
+        `(p: Jinaga.User) {\n` +
+        `    post: Test.Post [\n` +
+        `        post->author: Jinaga.User = p\n` +
+        `    ]\n` +
+        `} => post`;
+    const parser = new SpecificationParser(input);
+    parser.skipWhitespace();
+    const declaration = parser.parseDeclaration([]);
+    const specification = parser.parseSpecification();
+    const start = specification.given.map(g => {
+        const declared = declaration.find(d => d.name === g.label.name);
+        return declared!.declared.reference;
+    });
+    const namedStart = specification.given.reduce((map, g, index) => ({
+        ...map,
+        [g.label.name]: start[index]
+    }), {} as ReferencesByName);
+    const feed = buildFeeds(specification)[0];
+    const feedDefinition: FeedObject = { feed, namedStart };
+    const givenHash = computeObjectHash(namedStart);
+    return { feedDefinition, givenHash };
+}
+
+class FakeFactManager {
+    public listeners: { specification: Specification; onResult: (results: ProjectedResult[]) => Promise<void> }[] = [];
+    public removed: SpecificationListener[] = [];
+    addSpecificationListener(
+        specification: Specification,
+        onResult: (results: ProjectedResult[]) => Promise<void>
+    ): SpecificationListener {
+        const listener = { specification, onResult } as unknown as SpecificationListener;
+        this.listeners.push({ specification, onResult });
+        return listener;
+    }
+    removeSpecificationListener(listener: SpecificationListener): void {
+        this.removed.push(listener);
+    }
+}
+
+function ref(type: string, hash: string): FactReference {
+    return { type, hash };
+}
+function tuple(...facts: FactReference[]): { facts: FactReference[]; bookmark: string } {
+    return { facts, bookmark: "" };
+}
+function page(bookmark: string, tuples: { facts: FactReference[]; bookmark: string }[]): FeedResult {
+    return { type: "success", feed: { tuples, bookmark } as FactFeed };
+}
+function emptyPage(bookmark: string): FeedResult {
+    return page(bookmark, []);
+}
+
+function makeSession(
+    query: (bookmark: string) => Promise<FeedResult>,
+    options: {
+        initialBookmark?: string;
+        config?: ConstructorParameters<typeof FeedStreamSession>[8];
+        stream?: Stream<FeedResponse>;
+        factManager?: FakeFactManager;
+    } = {}
+): { session: FeedStreamSession; stream: Stream<FeedResponse>; received: FeedResponse[]; factManager: FakeFactManager } {
+    const { feedDefinition, givenHash } = buildFeedDefinition();
+    const start = feedDefinition.feed.given.map(g => feedDefinition.namedStart[g.label.name]);
+    const stream = options.stream ?? new Stream<FeedResponse>();
+    const received: FeedResponse[] = [];
+    stream.next(r => received.push(r));
+    const factManager = options.factManager ?? new FakeFactManager();
+    const session = new FeedStreamSession(
+        query,
+        factManager as unknown as FactManager,
+        feedDefinition,
+        start,
+        givenHash,
+        stream,
+        options.initialBookmark ?? "",
+        "regression-conn",
+        options.config ?? {}
+    );
+    return { session, stream, received, factManager };
+}
+
+async function settle(): Promise<void> {
+    for (let i = 0; i < 20; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+describe("FeedStreamSession regression", () => {
+    it("delivers a post-SYNC update on a paginating store and advances the bookmark", async () => {
+        const A = ref("Test.Post", "a");
+        const B = ref("Test.Post", "b");
+        // A realistic paginating store keyed by bookmark: A is history at "";
+        // after SYNC, B is delivered past "bm1" and the bookmark moves to "bm2".
+        const query = jest.fn(async (bookmark: string) => {
+            if (bookmark === "") return page("bm1", [tuple(A)]);
+            if (bookmark === "bm1") return emptyPage("bm1");
+            if (bookmark === "bm1+B") return page("bm2", [tuple(B)]);
+            return emptyPage("bm2");
+        });
+        // Second cycle needs a distinct bookmark once B is available; emulate
+        // that by having onInverseMatch flip the store's view.
+        let bReady = false;
+        const wrapped = jest.fn(async (bookmark: string) => {
+            if (bookmark === "bm1" && bReady) return page("bm2", [tuple(B)]);
+            return query(bookmark);
+        });
+        const { session, received } = makeSession(wrapped, { config: { pageDelayEvery: 0 } });
+
+        session.start();
+        await settle();
+        // Backfill delivered A then a SYNC frame at bm1.
+        expect(received).toEqual([
+            { references: [A], bookmark: "bm1" },
+            { references: [], bookmark: "bm1" }
+        ]);
+
+        // A real-time update arrives after SYNC.
+        bReady = true;
+        session.onInverseMatch([B]);
+        await settle();
+
+        expect(received.slice(2)).toEqual([
+            { references: [B], bookmark: "bm2" },
+            { references: [], bookmark: "bm2" }
+        ]);
+        // Bookmark advanced monotonically and never regressed.
+        expect(received.map(r => r.bookmark)).toEqual(["bm1", "bm1", "bm2", "bm2"]);
+    });
+
+    it("re-delivers a fact that was dropped as stale once a later trigger makes it completable", async () => {
+        const A = ref("Test.Post", "a");
+        let completable = false;
+        // Bookmark-respecting store: A only becomes visible past "" once its
+        // tuple is completable; afterward the bookmark advances to "bm1".
+        const query = jest.fn(async (bookmark: string) => {
+            if (completable && bookmark === "") return page("bm1", [tuple(A)]);
+            return emptyPage(bookmark === "" ? "" : "bm1");
+        });
+        const { session, received } = makeSession(query);
+
+        // First trigger: A's tuple cannot complete, so it is dropped and a
+        // SYNC frame is emitted without ever delivering A.
+        session.onInverseMatch([A]);
+        await settle();
+        expect(received).toEqual([{ references: [], bookmark: "" }]);
+        expect(session.waitlistSize).toBe(0);
+
+        // A becomes completable; a later trigger re-adds it and it is delivered.
+        completable = true;
+        session.onInverseMatch([A]);
+        await settle();
+        expect(received.slice(1)).toEqual([
+            { references: [A], bookmark: "bm1" },
+            { references: [], bookmark: "bm1" }
+        ]);
+    });
+
+    it("does not run concurrent cycles under a burst of triggers", async () => {
+        let concurrent = 0;
+        let maxConcurrent = 0;
+        const query = jest.fn(async () => {
+            concurrent++;
+            maxConcurrent = Math.max(maxConcurrent, concurrent);
+            await new Promise<void>(resolve => setImmediate(resolve));
+            concurrent--;
+            return emptyPage("");
+        });
+        const A = ref("Test.Post", "a");
+        const { session } = makeSession(query);
+
+        session.start();
+        for (let i = 0; i < 8; i++) {
+            session.onInverseMatch([A]);
+        }
+        await settle();
+
+        expect(maxConcurrent).toBe(1);
+    });
+
+    it("streams nothing once disposed while a query is in flight", async () => {
+        const A = ref("Test.Post", "a");
+        let resolveQuery: (value: FeedResult) => void = () => { };
+        const query = jest.fn(() => new Promise<FeedResult>(resolve => { resolveQuery = resolve; }));
+        const { session, received } = makeSession(query);
+
+        session.start();
+        // Let the cycle enter the awaited query.
+        await new Promise<void>(resolve => setImmediate(resolve));
+
+        // Dispose mid-query, then let the query resolve with a full page.
+        session.dispose();
+        resolveQuery(page("bm1", [tuple(A)]));
+        await settle();
+
+        // The post-dispose page must not be streamed.
+        expect(received).toEqual([]);
+    });
+});

--- a/test/feeds/feedStreamSessionSpec.ts
+++ b/test/feeds/feedStreamSessionSpec.ts
@@ -1,0 +1,351 @@
+import {
+    buildFeeds,
+    computeObjectHash,
+    FactFeed,
+    FactManager,
+    FactReference,
+    FeedObject,
+    FeedResponse,
+    ProjectedResult,
+    ReferencesByName,
+    Specification,
+    SpecificationListener,
+    SpecificationParser
+} from "jinaga";
+
+import { FeedResult } from "../../src/authorization/authorization-keystore";
+import { FeedStreamSession } from "../../src/feeds/feed-stream-session";
+import { Stream } from "../../src/http/stream";
+
+// Build a real, invertible feed specification so the session can register
+// inverse and anchor listeners during start().
+function buildFeedDefinition(): { feedDefinition: FeedObject; givenHash: string } {
+    const anchorHash = "anchorhash000000000000000000000000000000000000";
+    const input =
+        `let p: Jinaga.User = #${anchorHash}\n` +
+        `(p: Jinaga.User) {\n` +
+        `    post: Test.Post [\n` +
+        `        post->author: Jinaga.User = p\n` +
+        `    ]\n` +
+        `} => post`;
+    const parser = new SpecificationParser(input);
+    parser.skipWhitespace();
+    const declaration = parser.parseDeclaration([]);
+    const specification = parser.parseSpecification();
+    const start = specification.given.map(g => {
+        const declared = declaration.find(d => d.name === g.label.name);
+        return declared!.declared.reference;
+    });
+    const namedStart = specification.given.reduce((map, g, index) => ({
+        ...map,
+        [g.label.name]: start[index]
+    }), {} as ReferencesByName);
+    const feed = buildFeeds(specification)[0];
+    const feedDefinition: FeedObject = { feed, namedStart };
+    const givenHash = computeObjectHash(namedStart);
+    return { feedDefinition, givenHash };
+}
+
+// A FactManager test double that records listeners and lets tests drive them.
+class FakeFactManager {
+    public listeners: { specification: Specification; onResult: (results: ProjectedResult[]) => Promise<void> }[] = [];
+    public removed: SpecificationListener[] = [];
+
+    addSpecificationListener(
+        specification: Specification,
+        onResult: (results: ProjectedResult[]) => Promise<void>
+    ): SpecificationListener {
+        const listener = { specification, onResult } as unknown as SpecificationListener;
+        this.listeners.push({ specification, onResult });
+        return listener;
+    }
+
+    removeSpecificationListener(listener: SpecificationListener): void {
+        this.removed.push(listener);
+    }
+}
+
+function ref(type: string, hash: string): FactReference {
+    return { type, hash };
+}
+
+function tuple(...facts: FactReference[]): { facts: FactReference[]; bookmark: string } {
+    return { facts, bookmark: "" };
+}
+
+function page(bookmark: string, tuples: { facts: FactReference[]; bookmark: string }[]): FeedResult {
+    const feed: FactFeed = { tuples, bookmark };
+    return { type: "success", feed };
+}
+
+function emptyPage(bookmark: string): FeedResult {
+    return page(bookmark, []);
+}
+
+function makeSession(
+    query: (bookmark: string) => Promise<FeedResult>,
+    options: {
+        initialBookmark?: string;
+        config?: ConstructorParameters<typeof FeedStreamSession>[8];
+        stream?: Stream<FeedResponse>;
+        factManager?: FakeFactManager;
+    } = {}
+): { session: FeedStreamSession; stream: Stream<FeedResponse>; received: FeedResponse[]; factManager: FakeFactManager } {
+    const { feedDefinition, givenHash } = buildFeedDefinition();
+    const start = feedDefinition.feed.given.map(g => feedDefinition.namedStart[g.label.name]);
+    const stream = options.stream ?? new Stream<FeedResponse>();
+    const received: FeedResponse[] = [];
+    stream.next(r => received.push(r));
+    const factManager = options.factManager ?? new FakeFactManager();
+    const session = new FeedStreamSession(
+        query,
+        factManager as unknown as FactManager,
+        feedDefinition,
+        start,
+        givenHash,
+        stream,
+        options.initialBookmark ?? "",
+        "test-conn",
+        options.config ?? {}
+    );
+    return { session, stream, received, factManager };
+}
+
+async function settle(): Promise<void> {
+    for (let i = 0; i < 10; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+describe("FeedStreamSession", () => {
+    it("backfills to exhaustion then emits a SYNC frame", async () => {
+        const A = ref("Test.Post", "a");
+        const B = ref("Test.Post", "b");
+        const C = ref("Test.Post", "c");
+        const responses = [
+            page("bm1", [tuple(A), tuple(B)]),
+            page("bm2", [tuple(C)]),
+            emptyPage("bm2")
+        ];
+        let call = 0;
+        const { session, received } = makeSession(async () => responses[call++]);
+
+        session.start();
+        await settle();
+
+        expect(received).toEqual([
+            { references: [A, B], bookmark: "bm1" },
+            { references: [C], bookmark: "bm2" },
+            { references: [], bookmark: "bm2" }
+        ]);
+        // The last frame is the SYNC frame: empty references, current bookmark.
+        expect(received[received.length - 1].references).toEqual([]);
+    });
+
+    it("emits a SYNC frame immediately when there is no history", async () => {
+        const { session, received } = makeSession(async () => emptyPage(""));
+
+        session.start();
+        await settle();
+
+        expect(received).toEqual([{ references: [], bookmark: "" }]);
+    });
+
+    it("deduplicates facts across tuples within a page", async () => {
+        const A = ref("Test.Post", "a");
+        const B = ref("Test.Post", "b");
+        const C = ref("Test.Post", "c");
+        const responses = [
+            page("bm1", [tuple(A, B), tuple(B, C)]),
+            emptyPage("bm1")
+        ];
+        let call = 0;
+        const { session, received } = makeSession(async () => responses[call++]);
+
+        session.start();
+        await settle();
+
+        expect(received[0].references).toEqual([A, B, C]);
+    });
+
+    it("continues querying when facts arrive during a query (waitlist continuation)", async () => {
+        const A = ref("Test.Post", "a");
+        let call = 0;
+        let sessionRef: FeedStreamSession | null = null;
+        const query = jest.fn(async () => {
+            call++;
+            if (call === 1) {
+                // A fact arrives mid-query: enqueue it onto the waitlist.
+                sessionRef!.onInverseMatch([A]);
+                return emptyPage("");
+            }
+            if (call === 2) {
+                return page("bm1", [tuple(A)]);
+            }
+            return emptyPage("bm1");
+        });
+        const made = makeSession(query);
+        sessionRef = made.session;
+
+        made.session.start();
+        await settle();
+
+        // First empty + waitlist non-empty triggered a re-query that found A,
+        // then a final empty query produced the SYNC frame.
+        expect(made.received).toEqual([
+            { references: [A], bookmark: "bm1" },
+            { references: [], bookmark: "bm1" }
+        ]);
+        expect(query).toHaveBeenCalledTimes(3);
+    });
+
+    it("removes a fact from the waitlist only when its tuple is streamed", async () => {
+        const A = ref("Test.Post", "a");
+        const responses = [
+            page("bm1", [tuple(A)]),
+            emptyPage("bm1")
+        ];
+        let call = 0;
+        const { session, received } = makeSession(async () => responses[call++ ] ?? emptyPage("bm1"));
+
+        session.onInverseMatch([A]);
+        expect(session.waitlistSize).toBe(1);
+        await settle();
+
+        // Once A's tuple is streamed, it is removed and the cycle reaches SYNC.
+        expect(session.waitlistSize).toBe(0);
+        expect(received).toEqual([
+            { references: [A], bookmark: "bm1" },
+            { references: [], bookmark: "bm1" }
+        ]);
+    });
+
+    it("drops stale waitlist entries that never complete and emits SYNC", async () => {
+        const A = ref("Test.Post", "a");
+        const { session, received } = makeSession(async () => emptyPage(""));
+
+        session.onInverseMatch([A]);
+        expect(session.waitlistSize).toBe(1);
+        await settle();
+
+        // The query never returns A's tuple and no new trigger arrives, so the
+        // stale entry is dropped and a SYNC frame is emitted.
+        expect(session.waitlistSize).toBe(0);
+        expect(received).toEqual([{ references: [], bookmark: "" }]);
+    });
+
+    it("runs only one cycle at a time", async () => {
+        const A = ref("Test.Post", "a");
+        let concurrent = 0;
+        let maxConcurrent = 0;
+        let call = 0;
+        const query = jest.fn(async (_bookmark: string) => {
+            concurrent++;
+            maxConcurrent = Math.max(maxConcurrent, concurrent);
+            await new Promise<void>(resolve => setImmediate(resolve));
+            concurrent--;
+            call++;
+            return emptyPage("");
+        });
+        const { session } = makeSession(query);
+
+        // Fire several wake-ups in quick succession.
+        session.onInverseMatch([A]);
+        session.onInverseMatch([A]);
+        session.onInverseMatch([A]);
+        await settle();
+
+        expect(maxConcurrent).toBe(1);
+    });
+
+    it("caps the waitlist and closes the stream when exceeded", async () => {
+        const stream = new Stream<FeedResponse>();
+        const closeSpy = jest.spyOn(stream, "close");
+        // A query that never advances so the cycle cannot drain the waitlist.
+        const { session, factManager } = makeSession(
+            async () => emptyPage(""),
+            { stream, config: { waitlistCap: 2 } }
+        );
+
+        session.onInverseMatch([
+            ref("Test.Post", "a"),
+            ref("Test.Post", "b"),
+            ref("Test.Post", "c")
+        ]);
+
+        expect(closeSpy).toHaveBeenCalled();
+        // Listeners are torn down on graceful close.
+        expect(factManager.removed.length).toBe(factManager.listeners.length);
+    });
+
+    it("stops after the configured maximum number of pages", async () => {
+        let call = 0;
+        const query = jest.fn(async () => page(`bm${++call}`, [tuple(ref("Test.Post", `p${call}`))]));
+        const { session, received } = makeSession(query, { config: { maxInitialPages: 2, pageDelayEvery: 0 } });
+
+        session.start();
+        await settle();
+
+        // Exactly two pages streamed, then the cycle stops (no SYNC frame).
+        expect(query).toHaveBeenCalledTimes(2);
+        expect(received.length).toBe(2);
+        expect(received.every(r => r.references.length > 0)).toBe(true);
+    });
+
+    it("keeps the stream alive without SYNC when a query is denied", async () => {
+        const denied: FeedResult = { type: "denied", reason: "not authorized" };
+        const { session, received, stream } = makeSession(async () => denied);
+
+        session.start();
+        await settle();
+
+        expect(received).toEqual([]);
+        // Stream remains open so a later authorizing fact can wake the cycle.
+        expect((stream as any).closed).toBe(false);
+    });
+
+    it("only enqueues inverse results whose given subset matches", async () => {
+        const A = ref("Test.Post", "a");
+        const query = jest.fn(async () => emptyPage(""));
+        const { session, factManager } = makeSession(query);
+
+        session.start();
+        await settle();
+        query.mockClear();
+
+        const inverseListener = factManager.listeners[0];
+        expect(inverseListener).toBeDefined();
+
+        // A result whose tuple does not match this subscription's given.
+        const nonMatching: ProjectedResult = {
+            tuple: { p: ref("Jinaga.User", "someone-else"), post: A },
+            result: A
+        };
+        await inverseListener.onResult([nonMatching]);
+        await settle();
+
+        // The non-matching result is filtered out: no new cycle/query runs.
+        expect(query).not.toHaveBeenCalled();
+        expect(session.waitlistSize).toBe(0);
+    });
+
+    it("removes all listeners and stops cycling on dispose", async () => {
+        const A = ref("Test.Post", "a");
+        const query = jest.fn(async () => emptyPage(""));
+        const { session, factManager } = makeSession(query);
+
+        session.start();
+        await settle();
+        const registered = factManager.listeners.length;
+        expect(registered).toBeGreaterThan(0);
+
+        session.dispose();
+        expect(factManager.removed.length).toBe(registered);
+
+        query.mockClear();
+        // After dispose, further triggers are ignored.
+        session.onInverseMatch([A]);
+        await settle();
+        expect(query).not.toHaveBeenCalled();
+    });
+});

--- a/test/http/feedStreamSessionIntegrationSpec.ts
+++ b/test/http/feedStreamSessionIntegrationSpec.ts
@@ -1,0 +1,202 @@
+import {
+    AuthorizationRules,
+    buildModel,
+    dehydrateFact,
+    FactManager,
+    FeedCache,
+    FeedResponse,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    User
+} from "jinaga";
+
+import { AuthorizationKeystore } from "../../src/authorization/authorization-keystore";
+import { HttpRouter, RequestUser } from "../../src/http/router";
+import { Stream } from "../../src/http/stream";
+import { MemoryKeystore } from "../../src/memory/memory-keystore";
+
+// End-to-end coverage of the FeedStreamSession wired through HttpRouter
+// against a real in-memory FactManager. Exercises backfill, mid-backfill
+// inserts, the SYNC frame, and post-SYNC real-time updates.
+class Post {
+    public static Type = "stream.Post" as const;
+    public type = Post.Type;
+    constructor(public author: User, public body: string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Post, m => m.predecessor("author", User))
+);
+
+const userIdentity = { provider: "mock", id: "subscriber" };
+
+interface Harness {
+    router: HttpRouter;
+    factManager: FactManager;
+    storage: MemoryStore;
+    requestUser: RequestUser;
+    author: User;
+    authorRef: { type: string; hash: string };
+}
+
+async function makeHarness(): Promise<Harness> {
+    const storage = new MemoryStore();
+    const keystore = new MemoryKeystore();
+    const userFact = await keystore.getOrCreateUserFact(userIdentity);
+    const author = new User(userFact.fields.publicKey);
+    const authorRef = dehydrateFact(author)[0];
+
+    const fork = new PassThroughFork(storage);
+    const observable = new ObservableSource(storage);
+    const network = new NetworkNoOp();
+    const factManager = new FactManager(fork, observable, storage, network, []);
+
+    const authorizationRules = new AuthorizationRules(model)
+        .any(User)
+        .any(Post);
+    const authorization = new AuthorizationKeystore(
+        factManager, storage, keystore, authorizationRules, null);
+    const feedCache = new FeedCache();
+
+    const router = new HttpRouter(factManager, authorization, feedCache, "*");
+
+    return {
+        router,
+        factManager,
+        storage,
+        requestUser: { provider: userIdentity.provider, id: userIdentity.id, profile: {} as any },
+        author,
+        authorRef
+    };
+}
+
+async function waitForMicrotasks(): Promise<void> {
+    for (let i = 0; i < 10; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+function feedInput(authorHash: string): string {
+    return (
+        `let p: Jinaga.User = #${authorHash}\n` +
+        `(p: Jinaga.User) {\n` +
+        `    post: stream.Post [\n` +
+        `        post->author: Jinaga.User = p\n` +
+        `    ]\n` +
+        `} => post`
+    );
+}
+
+async function savePost(h: Harness, body: string): Promise<void> {
+    const post = new Post(h.author, body);
+    const envelopes = dehydrateFact(post).map(f => ({ fact: f, signatures: [] }));
+    await h.factManager.save(envelopes);
+}
+
+describe("HttpRouter streamFeed session integration", () => {
+    it("backfills all historical posts and ends with a SYNC frame", async () => {
+        const h = await makeHarness();
+        await h.factManager.save(dehydrateFact(h.author).map(f => ({ fact: f, signatures: [] })));
+        for (let i = 0; i < 5; i++) {
+            await savePost(h, `post-${i}`);
+        }
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, feedInput(h.authorRef.hash));
+        const feedHash: string = feedsResponse.feeds[0];
+
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+        const received: FeedResponse[] = [];
+        stream.next(r => received.push(r));
+
+        await waitForMicrotasks();
+        stream.close();
+
+        const distinctPosts = new Set(received.flatMap(r => r.references)
+            .filter(r => r.type === Post.Type).map(r => r.hash));
+        expect(distinctPosts.size).toBe(5);
+        // The final frame is the SYNC signal: empty references.
+        expect(received[received.length - 1].references).toEqual([]);
+    });
+
+    it("does not lose posts inserted during backfill", async () => {
+        const h = await makeHarness();
+        await h.factManager.save(dehydrateFact(h.author).map(f => ({ fact: f, signatures: [] })));
+        await savePost(h, "historical");
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, feedInput(h.authorRef.hash));
+        const feedHash: string = feedsResponse.feeds[0];
+
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+        const received: FeedResponse[] = [];
+        stream.next(r => received.push(r));
+
+        // Insert a post immediately, racing the backfill.
+        await savePost(h, "raced");
+        await waitForMicrotasks();
+        stream.close();
+
+        const distinctPosts = new Set(received.flatMap(r => r.references)
+            .filter(r => r.type === Post.Type).map(r => r.hash));
+        // Both the historical and the raced post are delivered.
+        expect(distinctPosts.size).toBe(2);
+        expect(received[received.length - 1].references).toEqual([]);
+    });
+
+    it("delivers post-SYNC updates in subsequent frames", async () => {
+        const h = await makeHarness();
+        await h.factManager.save(dehydrateFact(h.author).map(f => ({ fact: f, signatures: [] })));
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, feedInput(h.authorRef.hash));
+        const feedHash: string = feedsResponse.feeds[0];
+
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+        const received: FeedResponse[] = [];
+        stream.next(r => received.push(r));
+
+        await waitForMicrotasks();
+        const framesBeforeUpdate = received.length;
+        // The first frame is the immediate SYNC (no history).
+        expect(received[framesBeforeUpdate - 1].references).toEqual([]);
+
+        // A new post after SYNC should arrive in a later frame.
+        await savePost(h, "after-sync");
+        await waitForMicrotasks();
+        stream.close();
+
+        const newFrames = received.slice(framesBeforeUpdate);
+        const distinctPosts = new Set(newFrames.flatMap(r => r.references)
+            .filter(r => r.type === Post.Type).map(r => r.hash));
+        expect(distinctPosts.size).toBe(1);
+    });
+
+    it("cleans up listeners on disconnect", async () => {
+        const h = await makeHarness();
+        await h.factManager.save(dehydrateFact(h.author).map(f => ({ fact: f, signatures: [] })));
+
+        const removeSpy = jest.spyOn(h.factManager, "removeSpecificationListener");
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, feedInput(h.authorRef.hash));
+        const feedHash: string = feedsResponse.feeds[0];
+
+        const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
+            h.requestUser, { hash: feedHash }, {});
+        stream.next(() => { });
+        await waitForMicrotasks();
+
+        const removedBefore = removeSpy.mock.calls.length;
+        stream.close();
+
+        // Closing the stream disposes the session, removing every listener.
+        expect(removeSpy.mock.calls.length).toBeGreaterThan(removedBefore);
+
+        // A post saved after disconnect must not reach the closed stream.
+        await savePost(h, "after-close");
+        await waitForMicrotasks();
+    });
+});

--- a/test/http/streamFeedAnchorSpec.ts
+++ b/test/http/streamFeedAnchorSpec.ts
@@ -102,7 +102,9 @@ describe("HttpRouter streamFeed anchor handling", () => {
         stream.next(r => { received.push(r); });
 
         await waitForMicrotasks();
-        expect(received).toEqual([]);
+        // The session catches up immediately (no tuples, empty waitlist) and
+        // emits a SYNC frame with empty references. No post has arrived yet.
+        expect(received.flatMap(r => r.references)).toEqual([]);
 
         // Save the author + a post that joins to it.
         const post = new Post(h.author, "first");


### PR DESCRIPTION
## Overview

Implements the persistent feed proxy described in #152 and `docs/design/feeds-persistent-proxy-plan.md`. Introduces a per-connection `FeedStreamSession` that serializes all feed fetching and streaming through a single bookmark-driven **query cycle**, eliminating the race between real-time listener callbacks and bookmark mutation.

Closes #152.

## What changed

- **New `src/feeds/feed-stream-session.ts` (`FeedStreamSession`)** — owns the lifecycle and state of one streaming connection:
  - Backfills pages until the feed is exhausted, then emits a **SYNC frame** (`references: []` + current bookmark). The response schema is unchanged, so existing clients keep working; those that want an explicit "caught up" signal can treat empty `references` as SYNC.
  - Inverse and anchor observers no longer fetch or stream directly. They only enqueue fact references onto a **waitlist** and wake the cycle. Bookmark progresses monotonically within the cycle with no interleaving updates.
  - Facts arriving during pagination or after SYNC are picked up by continuing the cycle until both the query returns no tuples **and** the waitlist is empty.
  - Tuple completeness: a reference is removed from the waitlist only when the tuple containing it is streamed. Stale entries that can never complete are dropped to avoid spinning.
  - Single-cycle execution guard (`activeCycle` / `needsCycle`) prevents concurrent cycles per connection.
  - Configurable limits — `maxInitialPages`, `waitlistCap`, `pageDelayEvery`/`pageDelayMs` — with diagnostics. Exceeding the waitlist cap closes the stream gracefully and tears down listeners.
  - Per-stream telemetry (initial pages, references streamed, cycles, SYNC frames, waitlist high-water) emitted on dispose.

- **`src/http/router.ts`** — `streamFeed` now constructs a `FeedStreamSession`, calls `start()`, and disposes it on `stream.done()`. Removed the old `streamAllInitialResults` / `streamFeedResponse` flow and the inline listener wiring. The session reuses the existing `queryFeed` path, so intersected-feed-owner and distribution-denied semantics (keep the stream alive, serve empty) are preserved.

- **`src/jinaga-server.ts`** — exposes the limits via `JinagaServerConfig.feedStream`.

- **`src/index.ts`** — exports `FeedStreamSession`, `FeedStreamSessionConfig`, `defaultFeedStreamSessionConfig`.

## Note on bookmark semantics

Stores that return the full result set with a non-advancing bookmark (e.g. the in-memory store) are treated as exhausted after the first page, at which point the session emits SYNC. This avoids an infinite re-query loop while still guaranteeing a SYNC signal. Paginating stores (Postgres) advance the bookmark and reach SYNC on the first empty page as designed.

## Tests

- **Unit** — `test/feeds/feedStreamSessionSpec.ts`: backfill to exhaustion + SYNC, immediate SYNC with no history, deduplication, waitlist continuation, tuple-completeness removal, stale-entry drop, single-cycle guarantee, waitlist cap, max-pages limit, distribution-denied keeps stream alive, given-subset listener filtering, dispose cleanup.
- **Integration** — `test/http/feedStreamSessionIntegrationSpec.ts`: full historical backfill, no loss on mid-backfill inserts, post-SYNC updates, listener cleanup on disconnect (through the real `HttpRouter` + in-memory `FactManager`).
- Updated `test/http/streamFeedAnchorSpec.ts` to account for the new SYNC frame.

`npm test` (type-check + full Jest suite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FduxWp8PoYfsGBXEwHGvHh)_