### PR TITLE
Return per-feed distribution decisions from POST /feeds (#168 S1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "csv-stringify": "^6.6.0",
         "express": "^4.21.2",
-        "jinaga": "^6.8.3",
+        "jinaga": "^6.9.0",
         "pg": "^8.13.1"
       },
       "devDependencies": {
@@ -3955,9 +3955,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.8.3.tgz",
-      "integrity": "sha512-v3dvRQKlXj++uT9D/AxFfRIeKwzitqYAs9Fxx5Q+wbCyYM+wHv4eRH9qCRcOIjv/jnl8iO/3vGGFZz+z2eMQgw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.9.0.tgz",
+      "integrity": "sha512-05zPOOoSTRuY3JtGMIli1lVY+/BPSb3vOAgwOGyMNjYqbt9J+ZCaMK3yhTIyi6h1vJTgsUeYvPHyYTwbPWYOVA==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "csv-stringify": "^6.6.0",
     "express": "^4.21.2",
-    "jinaga": "^6.8.3",
+    "jinaga": "^6.9.0",
     "pg": "^8.13.1"
   }
 }

--- a/src/authorization/authorization-keystore.ts
+++ b/src/authorization/authorization-keystore.ts
@@ -2,6 +2,7 @@ import {
     Authorization,
     AuthorizationEngine,
     AuthorizationRules,
+    DistributionDenialCode,
     DistributionEngine,
     DistributionRules,
     FactEnvelope,
@@ -22,9 +23,20 @@ export interface DistributionIntersectionBranch {
     specification: Specification;
 }
 
+// The engine failure that made a subscription reactive (authorized via
+// intersection) or denied. Carried so POST /feeds can report the structured
+// per-feed decision (issue #168 S1) without recomputing distribution.
+export interface DistributionDenial {
+    reason: string;
+    code: DistributionDenialCode;
+}
+
 export type DistributionBranchesResult =
-    | { type: "success"; branches: DistributionIntersectionBranch[] }
-    | { type: "denied"; reason: string };
+    // Pass-through authorized when `denial` is absent; authorized-via-
+    // intersection (reactive) when `denial` carries the engine failure that
+    // triggered the intersection.
+    | { type: "success"; branches: DistributionIntersectionBranch[]; denial?: DistributionDenial }
+    | { type: "denied"; reason: string; code: DistributionDenialCode };
 
 export type FeedResult =
     | { type: "success"; feed: FactFeed }
@@ -241,10 +253,17 @@ export class AuthorizationKeystore implements Authorization, SubscriptionAuthori
         if (canDistribute.type === "success") {
             return { type: "success", branches: [{ start, specification }] };
         }
+        // Preserve the structured engine failure so the caller can classify
+        // the feed (issue #168 S1). `canDistribute` is narrowed to a failure
+        // here, so `code`/`reason` are available.
+        const denial: DistributionDenial = { reason: canDistribute.reason, code: canDistribute.code };
         const result = await this.distributionEngine.intersectForSubscribe(start, specification, userReference);
         if (!result.intersected) {
-            return { type: "denied", reason: canDistribute.reason };
+            return { type: "denied", reason: denial.reason, code: denial.code };
         }
-        return { type: "success", branches: result.branches };
+        // Authorized via intersection: the spec is denied for this user right
+        // now (denial carries why) but self-heals once the authorizing fact
+        // arrives. The router reports this as `reactive`.
+        return { type: "success", branches: result.branches, denial };
     }
 }

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -4,11 +4,13 @@ import {
     buildFeeds,
     computeObjectHash,
     Declaration,
+    DistributionDenialCode,
     FactEnvelope,
     FactManager,
     FactRecord,
     FactReference,
     FeedCache,
+    FeedDecision,
     FeedResponse,
     FeedsResponse,
     Forbidden,
@@ -598,8 +600,33 @@ export class HttpRouter {
                 intersected = branches.length !== 1 || branches[0].specification !== specification;
             }
 
+            // Classify the spec's distribution decision once; it applies to
+            // every feed hash the spec produces (issue #168 S1). Registration
+            // and keep-alive are unchanged — reactive and denied feeds are
+            // still accepted and served exactly as before; this only reports
+            // the decision. `reactive` is authorized-via-intersection: denied
+            // now, self-heals when the authorizing fact arrives.
+            let decision: FeedDecision["decision"];
+            let decisionCode: DistributionDenialCode | undefined;
+            let decisionReason: string;
+            if (intersectResult.type === "denied") {
+                decision = "denied";
+                decisionCode = intersectResult.code;
+                decisionReason = intersectResult.reason;
+            } else if (intersected) {
+                decision = "reactive";
+                decisionCode = intersectResult.denial?.code;
+                decisionReason = intersectResult.denial?.reason
+                    ?? "Authorized via intersection; awaiting the authorizing fact.";
+            } else {
+                decision = "authorized";
+                decisionCode = undefined;
+                decisionReason = "Distribution authorized.";
+            }
+
             const ownerKey = subscriptionOwnerKey(userIdentity);
             const feedHashes: string[] = [];
+            const decisions: FeedDecision[] = [];
             for (const branch of branches) {
                 const branchNamedStart = branch.specification.given.reduce((map, g, index) => ({
                     ...map,
@@ -608,6 +635,14 @@ export class HttpRouter {
                 const branchFeeds = buildFeeds(branch.specification);
                 const branchHashes = this.feedCache.addFeeds(branchFeeds, branchNamedStart);
                 feedHashes.push(...branchHashes);
+                for (const hash of branchHashes) {
+                    decisions.push({
+                        feed: hash,
+                        decision,
+                        ...(decisionCode !== undefined ? { code: decisionCode } : {}),
+                        reason: decisionReason
+                    });
+                }
                 if (intersected) {
                     for (const hash of branchHashes) {
                         // Bind the hash to its owner so a different
@@ -634,7 +669,8 @@ export class HttpRouter {
             }
 
             return {
-                feeds: feedHashes
+                feeds: feedHashes,
+                decisions
             }
         });
     }

--- a/test/authorization/subscriptionIntersectionSpec.ts
+++ b/test/authorization/subscriptionIntersectionSpec.ts
@@ -68,6 +68,8 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
         expect(result.branches).toHaveLength(1);
         expect(result.branches[0].specification).toBe(officeSpec);
         expect(result.branches[0].start).toEqual([companyRef]);
+        // Pass-through authorized: no engine denial is carried.
+        expect(result.denial).toBeUndefined();
     });
 
     it("returns intersected branches when the user is not yet authorized", async () => {
@@ -100,6 +102,12 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
             type: setup.subscriberFact.type,
             hash: setup.subscriberFact.hash
         });
+        // Authorized-via-intersection (reactive) carries the engine failure
+        // that triggered it: the authenticated subscriber is excluded until
+        // the authorizing Administrator fact arrives.
+        expect(result.denial).toBeDefined();
+        expect(result.denial?.code).toBe("principal-excluded");
+        expect(result.denial?.reason).toBeTruthy();
     });
 
     it("returns denied when no distribution rule applies to the spec", async () => {
@@ -122,6 +130,8 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
         expect(result.type).toBe("denied");
         if (result.type !== "denied") return;
         expect(result.reason).toBeTruthy();
+        // No rule covers this spec at all.
+        expect(result.code).toBe("no-matching-rule");
     });
 
     it("returns a passthrough branch when there are no distribution rules at all", async () => {
@@ -144,6 +154,8 @@ describe("AuthorizationKeystore.verifyDistributionOrIntersect", () => {
         if (result.type !== "success") return;
         expect(result.branches).toHaveLength(1);
         expect(result.branches[0].specification).toBe(officeSpec);
+        // No distribution engine, so nothing is denied — pure pass-through.
+        expect(result.denial).toBeUndefined();
     });
 });
 

--- a/test/http/lateAuthRecoverySpec.ts
+++ b/test/http/lateAuthRecoverySpec.ts
@@ -125,6 +125,19 @@ describe("late-auth subscription recovery", () => {
         expect(feedsResponse.feeds.length).toBeGreaterThan(0);
         const feedHash: string = feedsResponse.feeds[0];
 
+        // S1: the response reports a per-feed decision. This is the reactive
+        // (authorized-via-intersection) case — denied for the subscriber now,
+        // self-heals when the Administrator fact arrives — reported without
+        // any change to registration or keep-alive behavior.
+        expect(feedsResponse.decisions).toHaveLength(feedsResponse.feeds.length);
+        expect(feedsResponse.decisions.map((d: any) => d.feed).sort())
+            .toEqual([...feedsResponse.feeds].sort());
+        for (const d of feedsResponse.decisions) {
+            expect(d.decision).toBe("reactive");
+            expect(d.code).toBe("principal-excluded");
+            expect(d.reason).toBeTruthy();
+        }
+
         const stream: Stream<FeedResponse> = await (h.router as any).streamFeed(
             h.requestUser, { hash: feedHash }, {});
         expect(stream).not.toBeNull();
@@ -151,6 +164,38 @@ describe("late-auth subscription recovery", () => {
             .filter(r => r.type === Office.Type);
         expect(officesAfterAuth.map(r => r.hash))
             .toContain(dehydrateFact(existingOffice).find(f => f.type === Office.Type)!.hash);
+    });
+
+    it("reports an authorized pass-through decision when the user is already permitted", async () => {
+        const h = await makeHarness();
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+        await h.factManager.save(dehydrateFact(company).map(f => ({ fact: f, signatures: [] })));
+
+        // Grant the subscriber the Administrator role *before* subscribing, so
+        // the distribution rule authorizes the spec as-is — pass-through, no
+        // intersection.
+        const admin = new Administrator(company, h.subscriber, new Date("2026-05-27"));
+        await h.factManager.save(dehydrateFact(admin).map(f => ({ fact: f, signatures: [] })));
+
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    o: ${Office.Type} [\n` +
+            `        o->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => o`;
+
+        const feedsResponse = await (h.router as any).feeds(h.requestUser, input);
+        expect(feedsResponse.feeds.length).toBeGreaterThan(0);
+
+        // S1: authorized decisions carry no denial code.
+        expect(feedsResponse.decisions).toHaveLength(feedsResponse.feeds.length);
+        for (const d of feedsResponse.decisions) {
+            expect(d.decision).toBe("authorized");
+            expect(d.code).toBeUndefined();
+            expect(d.reason).toBeTruthy();
+        }
     });
 
     it("does not let another authenticated user reuse an intersected feed hash", async () => {
@@ -235,6 +280,16 @@ describe("late-auth subscription recovery", () => {
 
         const feedsResponse = await (h.router as any).feeds(h.requestUser, input);
         expect(feedsResponse.feeds.length).toBeGreaterThan(0);
+
+        // S1: no rule covers this spec, so the decision is `denied` with the
+        // structured `no-matching-rule` code. The feed is still registered and
+        // served (empty), exactly as before — this only reports the decision.
+        expect(feedsResponse.decisions).toHaveLength(feedsResponse.feeds.length);
+        for (const d of feedsResponse.decisions) {
+            expect(d.decision).toBe("denied");
+            expect(d.code).toBe("no-matching-rule");
+            expect(d.reason).toBeTruthy();
+        }
 
         // Polling the cached feed must also stay live (empty page, not 403).
         const feedHash: string = feedsResponse.feeds[0];


### PR DESCRIPTION
## Summary

Implements **S1** of #168: `POST /feeds` now returns a per-feed distribution `decision` inline, classifying each registered feed as `authorized` / `reactive` / `denied` with the engine's structured `code`. This is a pure reporting addition — registration, keep-alive, and streaming behavior are unchanged.

The blocking dependency (jinaga.js#207 W1–W3: structured denial codes + extended `FeedsResponse`/`FeedDecision` types) is now published in **jinaga 6.9.0**, so this bumps the dependency and consumes it.

## Changes

- **Bump `jinaga` `^6.8.3` → `^6.9.0`** — brings in `DistributionDenialCode`, `DistributionFailure.code`, and the `FeedDecision` / `FeedsResponse.decisions` types.
- **`authorization-keystore.ts`** — thread the engine's structured failure through `verifyDistributionOrIntersect`. The `denied` result now carries `code`; the authorized-via-intersection (**reactive**) result carries the triggering failure via an optional `denial: { reason, code }`. Pass-through success carries no `denial`.
- **`router.ts`** — the `feeds()` handler classifies the spec once and attaches a `FeedDecision` to every feed hash it produces, returning `{ feeds, decisions }`. `outputFeeds` serializes it automatically.

Classification:

| `verifyDistributionOrIntersect` result | `decision` | `code` |
|---|---|---|
| success, pass-through | `authorized` | — |
| success, via intersection | `reactive` | from the triggering engine failure (e.g. `principal-excluded`) |
| `denied` | `denied` | the engine `code` |

## Behavior / compatibility

- **No behavioral change** to feed registration, keep-alive, or streaming. Reactive and denied feeds are still registered and served exactly as before.
- `decisions` is optional; older clients ignore it.

## Tests

Extended the two existing harnesses (no new files) to assert all three classifications, both at the `verifyDistributionOrIntersect` unit level and the `feeds()` handler level:

- authorized pass-through → `authorized`, no `code`
- not-yet-authorized subscriber → `reactive`, `principal-excluded`
- no applicable rule → `denied`, `no-matching-rule`

Full suite green including `tsc --noEmit` on tests; `npm run build` clean.

## Follow-ups (separate items in #168, not in this PR)

- **S2** — correct per-user decisions on `POST /feeds` cache hits
- **S3** — structured `Trace.counter`/metric in place of the free-text warn
- **S4** — `feed_not_found` 404 body on cache miss

Closes #168 (S1 portion; tracking issue remains open for S2–S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)