### PR TITLE
Feed-decision cache hits, structured denial signal, and 404 body (#168 S2-S4)

### DIFF
--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -592,7 +592,17 @@ export class HttpRouter {
             let branches: DistributionIntersectionBranch[];
             let intersected: boolean;
             if (intersectResult.type === "denied") {
-                Trace.warn(`/feeds accepting spec without applicable distribution rule: ${intersectResult.reason}`);
+                // Structured, dashboard-observable signal that a feed was
+                // registered without an applicable distribution rule (issue
+                // #168 S3). The metric name is stable so a backend sees
+                // bounded cardinality; the denial code (a fixed 4-value enum)
+                // is the measurement dimension, so authoring errors
+                // (no-matching-rule / spec-more-restrictive-than-rule) are
+                // distinguishable from auth states (principal-excluded /
+                // not-authenticated) in CI and dashboards without grepping
+                // logs. The human-readable line is retained for correlation.
+                Trace.metric("distribution.unmatched", { [intersectResult.code]: 1 });
+                Trace.warn(`/feeds accepting spec without applicable distribution rule (${intersectResult.code}): ${intersectResult.reason}`);
                 branches = [{ start, specification }];
                 intersected = false;
             } else {
@@ -606,6 +616,17 @@ export class HttpRouter {
             // still accepted and served exactly as before; this only reports
             // the decision. `reactive` is authorized-via-intersection: denied
             // now, self-heals when the authorizing fact arrives.
+            //
+            // S2: the decision is recomputed from verifyDistributionOrIntersect
+            // on every POST /feeds — it is NOT cached by feed hash — so a
+            // repeated request always returns the correct *per-user* decision.
+            // This matters because a non-intersected feed hash is shared across
+            // users (it excludes the requester's identity): the same hash is
+            // `authorized` for a permitted user and `denied` for another, and
+            // a `reactive` decision becomes `authorized` once the authorizing
+            // fact arrives. Caching the FeedDecision by hash would leak one
+            // user's decision to another. addFeeds stays idempotent on the
+            // hash; only the classification is per-request.
             let decision: FeedDecision["decision"];
             let decisionCode: DistributionDenialCode | undefined;
             let decisionReason: string;
@@ -699,12 +720,16 @@ export class HttpRouter {
         return Trace.dependency("feed", params["hash"], async () => {
             const feedHash = params["hash"];
             if (!feedHash) {
+                // No hash in the route at all — a wrong URL, not a feed lookup.
                 return null;
             }
 
             const feedDefinition = await this.feedCache.getFeed(feedHash);
             if (!feedDefinition) {
-                return null;
+                // Known route, but the feed hash is unknown or expired. Signal
+                // this distinctly (issue #168 S4) so the client can re-register
+                // via POST /feeds instead of treating it as a routing error.
+                throw new FeedNotFound(feedHash);
             }
 
             const bookmark = query["b"] as string ?? "";
@@ -736,12 +761,16 @@ export class HttpRouter {
 
         const feedHash = params["hash"];
         if (!feedHash) {
+            // No hash in the route at all — a wrong URL, not a feed lookup.
             return null;
         }
 
         const feedDefinition = await this.feedCache.getFeed(feedHash);
         if (!feedDefinition) {
-            return null;
+            // Known route, but the feed hash is unknown or expired. Signal
+            // this distinctly (issue #168 S4) so the client can re-register
+            // via POST /feeds instead of treating it as a routing error.
+            throw new FeedNotFound(feedHash);
         }
 
         const bookmark = query["b"] as string ?? "";
@@ -936,9 +965,24 @@ function extractResults(obj: any): { result: any, count: number } {
     }
 }
 
+// A known/expired feed hash missed the feed cache. Distinct from a route
+// miss (wrong URL) so clients can tell "unknown/expired feed hash" — which is
+// recoverable by re-registering via POST /feeds — from "wrong URL" (issue
+// #168 S4). handleError maps this to a 404 with a machine-readable body.
+export class FeedNotFound extends Error {
+    constructor(public readonly feedHash: string) {
+        super(`Feed not found: ${feedHash}`);
+        this.name = "FeedNotFound";
+    }
+}
+
 function handleError(error: any, req: Request, res: Response, next: NextFunction) {
     const requestPath = req.path;
-    if (error instanceof Forbidden) {
+    if (error instanceof FeedNotFound) {
+        Trace.warn(`Feed not found: ${error.feedHash} (Path: ${requestPath})`);
+        res.type("text");
+        res.status(404).send("feed_not_found");
+    } else if (error instanceof Forbidden) {
         Trace.warn(`Forbidden: ${error.message} (Path: ${requestPath})`);
         res.type("text");
         res.status(403).send(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { AuthorizationKeystore } from "./authorization/authorization-keystore";
 export { DistributedFactCache } from "./authorization/distributed-fact-cache";
 export { FeedStreamSession, FeedStreamSessionConfig, defaultFeedStreamSessionConfig } from "./feeds/feed-stream-session";
 export { createLineReader } from "./http/line-reader";
-export { HttpRouter, RequestUser } from "./http/router";
+export { FeedNotFound, HttpRouter, RequestUser } from "./http/router";
 export { Stream } from "./http/stream";
 export { JinagaServer, JinagaServerConfig, JinagaServerInstance, tracePool } from "./jinaga-server";
 export { Keystore } from "./keystore";

--- a/test/http/lateAuthRecoverySpec.ts
+++ b/test/http/lateAuthRecoverySpec.ts
@@ -8,13 +8,16 @@ import {
     FeedResponse,
     MemoryStore,
     NetworkNoOp,
+    NoOpTracer,
     ObservableSource,
     PassThroughFork,
+    Trace,
+    Tracer,
     User
 } from "jinaga";
 
 import { AuthorizationKeystore } from "../../src/authorization/authorization-keystore";
-import { HttpRouter, RequestUser } from "../../src/http/router";
+import { FeedNotFound, HttpRouter, RequestUser } from "../../src/http/router";
 import { Stream } from "../../src/http/stream";
 import { MemoryKeystore } from "../../src/memory/memory-keystore";
 
@@ -96,6 +99,25 @@ async function makeHarness() {
 async function drainMicrotasks() {
     for (let i = 0; i < 8; i++) {
         await new Promise<void>(resolve => setImmediate(resolve));
+    }
+}
+
+// Records Trace.metric calls so tests can assert the structured distribution
+// signal (issue #168 S3) without grepping logs. Everything else is a no-op,
+// and dependency() still runs its operation so feeds() works unchanged.
+class CapturingTracer extends NoOpTracer implements Tracer {
+    public readonly metrics: { message: string; measurements: { [key: string]: number } }[] = [];
+    metric(message: string, measurements: { [key: string]: number }): void {
+        this.metrics.push({ message, measurements });
+    }
+}
+
+async function withTracer<T>(tracer: Tracer, action: () => Promise<T>): Promise<T> {
+    Trace.configure(tracer);
+    try {
+        return await action();
+    } finally {
+        Trace.configure(new NoOpTracer());
     }
 }
 
@@ -296,5 +318,118 @@ describe("late-auth subscription recovery", () => {
         const page = await (h.router as any).feed(h.requestUser, { hash: feedHash }, {});
         expect(page).not.toBeNull();
         expect(page.references).toEqual([]);
+    });
+
+    it("S2: recomputes the per-user decision on a repeated POST /feeds", async () => {
+        const h = await makeHarness();
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+        const office = new Office(company, "HQ");
+        await h.factManager.save(dehydrateFact(office).map(f => ({ fact: f, signatures: [] })));
+
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    o: ${Office.Type} [\n` +
+            `        o->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => o`;
+
+        // First registration: subscriber is not yet an Administrator, so the
+        // decision is reactive (authorized via intersection).
+        const first = await (h.router as any).feeds(h.requestUser, input);
+        expect(first.decisions.every((d: any) => d.decision === "reactive")).toBe(true);
+
+        // The authorizing fact arrives.
+        const admin = new Administrator(company, h.subscriber, new Date("2026-05-27"));
+        await h.factManager.save(dehydrateFact(admin).map(f => ({ fact: f, signatures: [] })));
+
+        // A repeated POST /feeds for the same spec now returns `authorized` —
+        // the decision self-healed rather than returning a stale cached value.
+        const second = await (h.router as any).feeds(h.requestUser, input);
+        expect(second.decisions.length).toBeGreaterThan(0);
+        for (const d of second.decisions) {
+            expect(d.decision).toBe("authorized");
+            expect(d.code).toBeUndefined();
+        }
+    });
+
+    it("S2: returns different per-user decisions for the same spec", async () => {
+        const h = await makeHarness();
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+        await h.factManager.save(dehydrateFact(company).map(f => ({ fact: f, signatures: [] })));
+
+        // Authorize the subscriber but not Mallory.
+        const admin = new Administrator(company, h.subscriber, new Date("2026-05-27"));
+        await h.factManager.save(dehydrateFact(admin).map(f => ({ fact: f, signatures: [] })));
+
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    o: ${Office.Type} [\n` +
+            `        o->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => o`;
+
+        const subscriberResponse = await (h.router as any).feeds(h.requestUser, input);
+        expect(subscriberResponse.decisions.every((d: any) => d.decision === "authorized")).toBe(true);
+
+        // Mallory is a different authenticated user with no Administrator fact.
+        const malloryRequest: RequestUser = {
+            provider: "mock", id: "mallory", profile: {} as any
+        };
+        await (h.router as any).login(malloryRequest);
+        const malloryResponse = await (h.router as any).feeds(malloryRequest, input);
+
+        // Same spec, different user: the decision is computed for Mallory, not
+        // reused from the subscriber. Mallory is not authorized, so the spec is
+        // rewritten via intersection into a reactive, user-specific feed.
+        expect(malloryResponse.decisions.every((d: any) => d.decision === "reactive")).toBe(true);
+        // The reactive rewrite yields a distinct, owner-bound hash — never the
+        // subscriber's authorized pass-through hash.
+        expect(malloryResponse.feeds).not.toEqual(subscriberResponse.feeds);
+    });
+
+    it("S3: emits a structured distribution.unmatched metric tagged by code on denial", async () => {
+        const h = await makeHarness();
+        const company = new Company(h.creator, "Acme");
+        const companyRef = dehydrateFact(company).find(f => f.type === Company.Type)!;
+        await h.factManager.save(dehydrateFact(company).map(f => ({ fact: f, signatures: [] })));
+
+        // A spec no distribution rule covers → denied · no-matching-rule.
+        const input =
+            `let p1: ${Company.Type} = #${companyRef.hash}\n` +
+            `(p1: ${Company.Type}) {\n` +
+            `    a: ${Administrator.Type} [\n` +
+            `        a->company: ${Company.Type} = p1\n` +
+            `    ]\n` +
+            `} => a`;
+
+        const tracer = new CapturingTracer();
+        await withTracer(tracer, () => (h.router as any).feeds(h.requestUser, input));
+
+        const unmatched = tracer.metrics.filter(m => m.message === "distribution.unmatched");
+        expect(unmatched).toHaveLength(1);
+        // Stable metric name, denial code as the (bounded) measurement key.
+        expect(unmatched[0].measurements).toEqual({ "no-matching-rule": 1 });
+    });
+
+    it("S4: throws FeedNotFound for an unknown feed hash, but not for a missing hash", async () => {
+        const h = await makeHarness();
+
+        // A known route with an unknown/expired hash is a distinct condition
+        // from a route miss: the method throws FeedNotFound (handleError maps
+        // it to a 404 with a `feed_not_found` body), rather than returning the
+        // generic null → "Not Found".
+        await expect((h.router as any).feed(h.requestUser, { hash: "deadbeef" }, {}))
+            .rejects.toBeInstanceOf(FeedNotFound);
+        await expect((h.router as any).streamFeed(h.requestUser, { hash: "deadbeef" }, {}))
+            .rejects.toBeInstanceOf(FeedNotFound);
+
+        // A missing hash param (wrong URL) still collapses to the generic 404
+        // path — the method returns null, unchanged.
+        const missing = await (h.router as any).feed(h.requestUser, {}, {});
+        expect(missing).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

Implements **S2, S3, and S4** of #168, building on the S1 work merged in #172. Together these complete the server-side per-feed distribution diagnostics.

## S2 — Correct per-user decisions on repeated `POST /feeds`

The decision is recomputed from `verifyDistributionOrIntersect` on **every** request rather than cached by feed hash, so a repeat call always reflects current per-user state:
- a `reactive` decision self-heals to `authorized` once the authorizing fact arrives, and
- two different users get different decisions for the same spec.

Documented the invariant: a non-intersected feed hash is **shared across users** (it excludes the requester's identity), so caching the `FeedDecision` by hash would leak one user's decision to another. `addFeeds` stays idempotent on the hash; only the classification is per-request. Added regression tests for both the self-heal transition and the two-user divergence.

## S3 — Structured denial signal

Promoted the free-text `Trace.warn` on the `/feeds` denial path to:

```ts
Trace.metric("distribution.unmatched", { [code]: 1 });
```

Stable metric name (bounded cardinality); the denial `code` (a fixed 4-value enum) is the measurement dimension, so authoring errors (`no-matching-rule` / `spec-more-restrictive-than-rule`) are distinguishable from auth states (`principal-excluded` / `not-authenticated`) in CI and dashboards without grepping logs. The human-readable warn is retained (now including the code) for correlation.

## S4 — Machine-readable feed 404

A missing/expired feed hash (`feedCache.getFeed` miss) now throws a typed `FeedNotFound`, which `handleError` maps to `404 feed_not_found` — distinct from the generic `Not Found` of a route miss, so clients can tell "unknown/expired feed hash" (recoverable by re-registering via `POST /feeds`) from "wrong URL." A truly missing hash param still returns `null` → generic 404. `FeedNotFound` is exported from the package index alongside `HttpRouter`.

## Tests

Added to `test/http/lateAuthRecoverySpec.ts` (uses the existing router harness):
- **S2** — reactive→authorized self-heal on repeat; same spec / different users → different decisions
- **S3** — a capturing `Tracer` asserts the `distribution.unmatched` metric with the code as the measurement key
- **S4** — `feed()` and `streamFeed()` throw `FeedNotFound` for an unknown hash; a missing hash param still returns `null`

Full suite green including `tsc --noEmit`; `npm run build` clean.

**Verification note:** behavior is driven through the router's own methods end-to-end, not through a live Express server — `handleError`'s status/body mapping is asserted by construction, not by an HTTP round-trip. Happy to add a supertest HTTP test if preferred.

## Follow-ups (downstream, separate repos)

This completes jinaga-server's part of the cross-repo chain. Next: jinaga.js W4–W9/W8b (client consumes `decisions`), then factual-mcp#116.

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)