### PR TITLE
Authorize graph saves as a single batch to fix multi-hop auth over 20 facts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "csv-stringify": "^6.6.0",
         "express": "^4.21.2",
-        "jinaga": "^6.9.0",
+        "jinaga": "^6.11.1",
         "pg": "^8.13.1"
       },
       "devDependencies": {
@@ -3955,9 +3955,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.9.0.tgz",
-      "integrity": "sha512-05zPOOoSTRuY3JtGMIli1lVY+/BPSb3vOAgwOGyMNjYqbt9J+ZCaMK3yhTIyi6h1vJTgsUeYvPHyYTwbPWYOVA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.11.1.tgz",
+      "integrity": "sha512-frkq+ksi+BkWhqly6yyKZKlud8CQ1aNFOe0kUH/uVbf4RYzXWfb2Njs4HjW9Bqb1MKvRYSxenRoUQHQ3zUrPFQ==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "csv-stringify": "^6.6.0",
     "express": "^4.21.2",
-    "jinaga": "^6.9.0",
+    "jinaga": "^6.11.1",
     "pg": "^8.13.1"
   }
 }

--- a/src/authorization/authorization-keystore.ts
+++ b/src/authorization/authorization-keystore.ts
@@ -65,6 +65,10 @@ export interface SubscriptionAuthorizer {
 import { Keystore } from "../keystore";
 import { DistributedFactCache } from "./distributed-fact-cache";
 
+function factKey(reference: FactReference): string {
+    return `${reference.type}:${reference.hash}`;
+}
+
 export class AuthorizationKeystore implements Authorization, SubscriptionAuthorizer {
     private authorizationEngine: AuthorizationEngine | null;
     private distributionEngine: DistributionEngine | null;
@@ -188,14 +192,17 @@ export class AuthorizationKeystore implements Authorization, SubscriptionAuthori
             const signedFacts = (userIdentity && factsToSign.length > 0)
                 ? await this.keystore.signFacts(userIdentity, factsToSign)
                 : [];
+            const envelopeByFact = new Map<string, FactEnvelope>(
+                envelopes.map(e => [factKey(e.fact), e]));
+            const signedFactByFact = new Map<string, FactEnvelope>(
+                signedFacts.map(f => [factKey(f.fact), f]));
             const authorizedEnvelopes: FactEnvelope[] = results.map(r => {
-                const isFact = factReferenceEquals(r.fact);
-                const envelope = envelopes.find(e => isFact(e.fact));
+                const envelope = envelopeByFact.get(factKey(r.fact));
                 if (!envelope) {
                     throw new Error("Fact not found in envelopes.");
                 }
                 if (r.verdict === "Accept") {
-                    const signedFact = signedFacts.find(f => isFact(f.fact));
+                    const signedFact = signedFactByFact.get(factKey(r.fact));
                     const userSignatures = signedFact
                         ? signedFact.signatures
                         : [];

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -474,7 +474,7 @@ export class HttpRouter {
             // Otherwise, a graph body that flushes in chunks (GraphDeserializer
             // flushes every 20 facts) would authorize each chunk independently,
             // and a fact whose rule needs a predecessor from an earlier chunk
-            // would fail with "The fact : is not defined." (issue #175).
+            // would fail with "The fact <type>:<hash> is not defined." (issue #175).
             const allEnvelopes: FactEnvelope[] = [];
             await graphSource.read(async (envelopes) => {
                 if (!verifyEnvelopes(envelopes)) {

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -469,12 +469,24 @@ export class HttpRouter {
     private save(user: RequestUser | null, graphSource: GraphSource): Promise<void> {
         return Trace.dependency("save", "", async () => {
             const userIdentity = serializeUserIdentity(user);
+            // Signatures are verified per flush as they stream in, but the
+            // envelopes are accumulated and authorized as a single batch.
+            // Otherwise, a graph body that flushes in chunks (GraphDeserializer
+            // flushes every 20 facts) would authorize each chunk independently,
+            // and a fact whose rule needs a predecessor from an earlier chunk
+            // would fail with "The fact : is not defined." (issue #175).
+            const allEnvelopes: FactEnvelope[] = [];
             await graphSource.read(async (envelopes) => {
                 if (!verifyEnvelopes(envelopes)) {
                     throw new Forbidden("The signatures on the facts are invalid.");
                 }
-                await this.authorization.save(userIdentity, envelopes);
+                allEnvelopes.push(...envelopes);
             });
+            try {
+                await this.authorization.save(userIdentity, allEnvelopes);
+            } catch (error) {
+                throw toSaveAuthorizationError(error, allEnvelopes);
+            }
         });
     }
 
@@ -974,6 +986,32 @@ export class FeedNotFound extends Error {
         super(`Feed not found: ${feedHash}`);
         this.name = "FeedNotFound";
     }
+}
+
+// Authorization rule evaluation reports a missing predecessor as a plain
+// Error of this shape (see authorizationRules.ts / specification-runner.ts
+// in jinaga). It surfaces when the client's save request didn't include the
+// full closure of facts a rule needs to walk. Map it to a diagnosable 4xx
+// instead of an opaque 500 (issue #175).
+const FACT_NOT_DEFINED_PATTERN = /^The fact (\S+):(\S+) is not defined\.$/;
+
+function toSaveAuthorizationError(error: any, envelopes: FactEnvelope[]): any {
+    if (error instanceof Error) {
+        const match = FACT_NOT_DEFINED_PATTERN.exec(error.message);
+        if (match) {
+            const [, factType, factHash] = match;
+            const factTypesInBatch = Array.from(new Set(envelopes.map(e => e.fact.type))).join(", ");
+            Trace.warn(
+                `Save authorization could not resolve predecessor ${factType}:${factHash} ` +
+                `among ${envelopes.length} fact(s) in the request (types: ${factTypesInBatch}).`
+            );
+            return new Invalid(
+                `The fact ${factType}:${factHash} is required to authorize this save but was not included in the request. ` +
+                `Ensure the full closure of predecessors needed by your authorization rules is sent together.`
+            );
+        }
+    }
+    return error;
 }
 
 function handleError(error: any, req: Request, res: Response, next: NextFunction) {

--- a/test/http/graphSaveMultiHopAuthSpec.ts
+++ b/test/http/graphSaveMultiHopAuthSpec.ts
@@ -1,0 +1,126 @@
+import {
+    AuthorizationRules,
+    buildModel,
+    dehydrateFact,
+    DistributionRules,
+    FactEnvelope,
+    FactManager,
+    FactRecord,
+    FeedCache,
+    GraphDeserializer,
+    GraphSerializer,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    User
+} from "jinaga";
+
+import { AuthorizationKeystore } from "../../src/authorization/authorization-keystore";
+import { HttpRouter, RequestUser } from "../../src/http/router";
+import { MemoryKeystore } from "../../src/memory/memory-keystore";
+
+class Filler {
+    static Type = "GraphSave.Filler" as const;
+    public type = Filler.Type;
+    constructor(public value: number) { }
+}
+
+class Workspace {
+    static Type = "GraphSave.Workspace" as const;
+    public type = Workspace.Type;
+    constructor(public owner: User, public identifier: string) { }
+}
+
+class Application {
+    static Type = "GraphSave.Application" as const;
+    public type = Application.Type;
+    constructor(public workspace: Workspace, public name: string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Filler)
+    .type(Workspace, w => w.predecessor("owner", User))
+    .type(Application, a => a.predecessor("workspace", Workspace))
+);
+
+function createReadLine(input: string) {
+    const lines = input.split("\n");
+    if (lines[lines.length - 1] === "") {
+        lines.pop();
+    }
+    return async () => {
+        const line = lines.shift();
+        return line !== undefined ? line : null;
+    };
+}
+
+// Regression test for issue #175: HttpRouter.save() used to pass its
+// authorization call directly as GraphDeserializer's per-flush callback, so
+// a graph body that split across flush boundaries (every 20 facts)
+// authorized each flush independently. A fact whose rule needs a multi-hop
+// predecessor chain landing in an earlier flush then failed with
+// "The fact : is not defined." (surfaced to clients as a 500). This drives
+// the real application/x-jinaga-graph-v1 code path end to end.
+describe("POST /save with a multi-flush graph body", () => {
+    it("authorizes a fact whose multi-hop predecessors landed in a prior flush batch", async () => {
+        const store = new MemoryStore();
+        const keystore = new MemoryKeystore();
+        const ownerIdentity = { provider: "mock", id: "owner" };
+        const ownerFact = await keystore.getOrCreateUserFact(ownerIdentity);
+        const owner = new User(ownerFact.fields.publicKey);
+
+        const fork = new PassThroughFork(store);
+        const observable = new ObservableSource(store);
+        const network = new NetworkNoOp();
+        const factManager = new FactManager(fork, observable, store, network, []);
+
+        const authorizationRules = new AuthorizationRules(model)
+            .any(Filler.Type)
+            .any(User.Type)
+            .any(Workspace.Type)
+            .type(Application, app => app.workspace.owner);
+        const distributionRules = new DistributionRules([]);
+        const authorization = new AuthorizationKeystore(
+            factManager, store, keystore, authorizationRules, distributionRules);
+        const feedCache = new FeedCache();
+        const router = new HttpRouter(factManager, authorization, feedCache, "*");
+
+        const requestUser: RequestUser = {
+            provider: ownerIdentity.provider,
+            id: ownerIdentity.id,
+            profile: {} as any
+        };
+
+        // Pad the graph with enough leading facts that the real predecessor
+        // chain (owner -> workspace -> application) crosses the
+        // GraphDeserializer's default 20-fact flush threshold, landing
+        // Application in a later flush than its predecessors.
+        const fillerRecords: FactRecord[] = [];
+        for (let i = 0; i < 18; i++) {
+            fillerRecords.push(...dehydrateFact(new Filler(i)));
+        }
+        const chainRecords = dehydrateFact(new Application(new Workspace(owner, "workspace-1"), "application-1"));
+
+        const allRecords = [...fillerRecords, ...chainRecords];
+        expect(allRecords.length).toBeGreaterThan(20);
+        expect(allRecords[allRecords.length - 1].type).toBe(Application.Type);
+
+        const envelopes: FactEnvelope[] = allRecords.map(fact => ({ fact, signatures: [] }));
+
+        // Round-trip through the wire protocol so the test exercises the
+        // real GraphDeserializer flush boundary, not a hand-picked batch.
+        const lines: string[] = [];
+        new GraphSerializer(chunk => lines.push(chunk)).serialize(envelopes);
+        const wireText = lines.join("");
+        const readLine = createReadLine(wireText);
+        const graphSource = new GraphDeserializer(readLine);
+
+        await expect((router as any).save(requestUser, graphSource)).resolves.toBeUndefined();
+
+        const applicationRecord = chainRecords.find(f => f.type === Application.Type)!;
+        const saved = await store.whichExist([{ type: Application.Type, hash: applicationRecord.hash }]);
+        expect(saved.length).toBe(1);
+    });
+});

--- a/test/http/graphSaveMultiHopAuthSpec.ts
+++ b/test/http/graphSaveMultiHopAuthSpec.ts
@@ -61,7 +61,7 @@ function createReadLine(input: string) {
 // a graph body that split across flush boundaries (every 20 facts)
 // authorized each flush independently. A fact whose rule needs a multi-hop
 // predecessor chain landing in an earlier flush then failed with
-// "The fact : is not defined." (surfaced to clients as a 500). This drives
+// "The fact <type>:<hash> is not defined." (surfaced to clients as a 500). This drives
 // the real application/x-jinaga-graph-v1 code path end to end.
 describe("POST /save with a multi-flush graph body", () => {
     it("authorizes a fact whose multi-hop predecessors landed in a prior flush batch", async () => {


### PR DESCRIPTION
## Summary

- `HttpRouter.save()` used to pass its `authorization.save()` call directly as `GraphDeserializer`'s per-flush callback. `GraphDeserializer` flushes every 20 facts, so each flush was authorized as an independent batch. A fact whose authorization rule needed a predecessor hop through a fact that landed in an earlier flush failed with a plain `Error` ("The fact `type:hash` is not defined.") that fell through to an opaque HTTP 500.
- `save()` now accumulates the full stream's envelopes (signatures are still verified per flush, streaming) and calls `authorization.save()` once with the complete set, matching the JSON `/save` path's existing semantics.
- A residual "fact is not defined" error from authorization rule evaluation (a genuinely incomplete request, not a flush artifact) is now mapped to a 400 with an actionable message, and logged with the fact type/hash and batch composition for diagnosis.
- Bumps the `jinaga` dependency to 6.11.1, which independently fixes the same class of failure (per jinaga/jinaga.js#224) by falling back to storage when a predecessor isn't present in the current authorization batch.

## Test plan

- [x] Added `test/http/graphSaveMultiHopAuthSpec.ts`: drives `HttpRouter.save()` through a real `application/x-jinaga-graph-v1` wire round-trip with a 21-fact graph whose multi-hop authorization rule's predecessor chain crosses the `GraphDeserializer` flush boundary, and asserts the save succeeds and the fact is persisted.
- [x] `npm test` (type-check + full Jest suite) passes.

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgu1uArxPp4FEefXYX3cWs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jgu1uArxPp4FEefXYX3cWs)_