### PR TITLE
Fix unique-violation race when concurrently creating a user's key pair

### DIFF
--- a/integration-test/jinaga-test/postgres-keystore-race.test.js
+++ b/integration-test/jinaga-test/postgres-keystore-race.test.js
@@ -1,0 +1,68 @@
+const { Pool } = require('pg');
+const { PostgresKeystore } = require('jinaga-server');
+
+const host = "db";
+const connectionString = `postgresql://dev:devpw@${host}:5432/integrationtest`;
+
+const pool = new Pool({
+    connectionString
+});
+
+describe('PostgresKeystore concurrency race', () => {
+    afterAll(async () => {
+        await pool.end();
+    });
+
+    beforeEach(async () => {
+        // Ensure no row exists yet for the test identities so the
+        // select-then-insert path is exercised from a clean state.
+        await pool.query(`DELETE FROM public."user" WHERE provider = 'test-provider'`);
+    });
+
+    it('should not fail when two concurrent requests create the same user key pair', async () => {
+        const userIdentity = { provider: 'test-provider', id: 'race-user-1' };
+
+        // Two separate keystore instances model two concurrent requests that
+        // each build a fresh runtime (empty in-process cache), as described in
+        // issue #177. Both SELECT zero rows and race to INSERT.
+        const keystoreA = new PostgresKeystore(pool, 'public');
+        const keystoreB = new PostgresKeystore(pool, 'public');
+
+        const [factA, factB] = await Promise.all([
+            keystoreA.getOrCreateUserFact(userIdentity),
+            keystoreB.getOrCreateUserFact(userIdentity)
+        ]);
+
+        // Both requests succeed and observe the same public key (the winner's).
+        expect(factA.type).toBe('Jinaga.User');
+        expect(factB.type).toBe('Jinaga.User');
+        expect(factA.fields.publicKey).toBe(factB.fields.publicKey);
+        expect(factA.hash).toBe(factB.hash);
+
+        // Exactly one row was persisted for the identity.
+        const { rows } = await pool.query(
+            `SELECT public_key FROM public."user" WHERE provider = $1 AND user_identifier = $2`,
+            [userIdentity.provider, userIdentity.id]);
+        expect(rows.length).toBe(1);
+        expect(rows[0].public_key).toBe(factA.fields.publicKey);
+    });
+
+    it('should tolerate many concurrent creations of the same identity', async () => {
+        const userIdentity = { provider: 'test-provider', id: 'race-user-2' };
+
+        // A larger fan-out of fresh runtimes all racing on the same identity.
+        const keystores = Array.from({ length: 8 }, () => new PostgresKeystore(pool, 'public'));
+
+        const facts = await Promise.all(
+            keystores.map(keystore => keystore.getOrCreateUserFact(userIdentity)));
+
+        // Every caller resolves to the same key pair.
+        const publicKeys = new Set(facts.map(fact => fact.fields.publicKey));
+        expect(publicKeys.size).toBe(1);
+
+        const { rows } = await pool.query(
+            `SELECT public_key FROM public."user" WHERE provider = $1 AND user_identifier = $2`,
+            [userIdentity.provider, userIdentity.id]);
+        expect(rows.length).toBe(1);
+    });
+});

--- a/integration-test/jinaga-test/postgres-keystore-race.test.js
+++ b/integration-test/jinaga-test/postgres-keystore-race.test.js
@@ -16,7 +16,7 @@ describe('PostgresKeystore concurrency race', () => {
     beforeEach(async () => {
         // Ensure no row exists yet for the test identities so the
         // select-then-insert path is exercised from a clean state.
-        await pool.query(`DELETE FROM public."user" WHERE provider = 'test-provider'`);
+        await pool.query(`DELETE FROM public."user" WHERE provider = $1`, ['test-provider']);
     });
 
     it('should not fail when two concurrent requests create the same user key pair', async () => {

--- a/src/postgres/postgres-keystore.ts
+++ b/src/postgres/postgres-keystore.ts
@@ -118,7 +118,7 @@ export class PostgresKeystore implements Keystore {
             `INSERT INTO ${this.schema}.user (provider, user_identifier, private_key, public_key)
              VALUES ($1, $2, $3, $4)
              ON CONFLICT (user_identifier, provider) DO NOTHING
-             RETURNING public_key, private_key`,
+             RETURNING 1`,
             [userIdentity.provider, userIdentity.id, keyPair.privatePem, keyPair.publicPem]);
         if (rows.length === 1) {
             return keyPair;

--- a/src/postgres/postgres-keystore.ts
+++ b/src/postgres/postgres-keystore.ts
@@ -114,9 +114,21 @@ export class PostgresKeystore implements Keystore {
 
     private async generateKeyPair(connection: PoolClient, userIdentity: UserIdentity): Promise<KeyPair> {
         const keyPair = generateKeyPair();
-        await connection.query(`INSERT INTO ${this.schema}.user (provider, user_identifier, private_key, public_key) VALUES ($1, $2, $3, $4)`,
+        const { rows } = await connection.query(
+            `INSERT INTO ${this.schema}.user (provider, user_identifier, private_key, public_key)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (user_identifier, provider) DO NOTHING
+             RETURNING public_key, private_key`,
             [userIdentity.provider, userIdentity.id, keyPair.privatePem, keyPair.publicPem]);
-        return keyPair;
+        if (rows.length === 1) {
+            return keyPair;
+        }
+        // Lost the race: a concurrent request inserted this user's key pair
+        // between our SELECT and INSERT. The ON CONFLICT clause suppressed the
+        // unique-violation (23505) on ux_user, so read back the winner's key
+        // pair instead of surfacing a duplicate-key error. selectOrInsertKeyPair
+        // will now find exactly one row.
+        return this.selectOrInsertKeyPair(connection, userIdentity);
     }
 }
 


### PR DESCRIPTION
Fixes #177.

## Problem

`PostgresKeystore.selectOrInsertKeyPair` does a check-then-act (`SELECT` then an unconditional `INSERT`) whenever a user's key pair is absent from both the in-process `cache` and the database. `getOrCreateUserFact` / `getOrGenerateKeyPair` runs on every `/login` and again on every `/feeds` registration via `getKnownFacts`, so two concurrent requests for the **same identity** — e.g. a `/login` immediately followed by concurrent `/feeds` calls right after a fresh deploy, or any client that builds a fresh runtime per operation — can both:

1. `SELECT` and see zero rows,
2. both call `generateKeyPair` and both `INSERT`,
3. one succeeds; the other raises a Postgres unique-violation (`23505`) on `ux_user`.

`setup.sql` places a unique index on exactly those columns:

```sql
CREATE UNIQUE INDEX ux_user ON public."user" USING btree (user_identifier, provider);
```

This is a classic TOCTOU race. The reporter observed transient `500`s in production (two failures at the identical millisecond, 4–8 ms fast) for a per-tenant wrapper that re-authenticates per operation.

## Fix

Make the insert idempotent under the race using `INSERT ... ON CONFLICT (user_identifier, provider) DO NOTHING RETURNING`:

- If a row is returned, we won the race and return the freshly generated pair.
- If `ON CONFLICT` suppressed the insert, we lost the race, so we read back the winner's key pair via `selectOrInsertKeyPair`, which now finds exactly one row.

This resolves the race deterministically in a single statement, rather than depending on the generic transient-error retry in `ConnectionFactory.with` to catch the exception after the fact (which also adds backoff latency and error-level log noise on every lost race).

`MemoryKeystore` was audited and is unaffected: its get-or-create path is fully synchronous, so no interleaving is possible in Node's single-threaded event loop.

## Testing

- `npm run build` and `npm test` (type-check + Jest unit suite) pass.
- Verified the fix end-to-end against a real PostgreSQL 16 instance using the exact `ux_user` schema: 8 fresh `PostgresKeystore` instances (empty caches) racing `getOrCreateUserFact` for the same identity all resolve to a single consistent key pair with exactly one persisted row.
- Added `integration-test/jinaga-test/postgres-keystore-race.test.js`, which races several fresh keystore instances on the same identity and asserts all callers agree on one key pair with a single row (both a 2-way and an 8-way fan-out case), following the existing `postgres-duplicates.test.js` conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpKfuWfDYnrLvL6Qr2pVkp)_