### PR TITLE
Rule out Jinaga.User feed-SQL trigger for issue #179 with a regression test

### DIFF
--- a/test/postgres/userGivenFeedSqlSpec.ts
+++ b/test/postgres/userGivenFeedSqlSpec.ts
@@ -1,0 +1,92 @@
+import { buildFeeds, dehydrateReference, getAllFactTypes, getAllRoles, SpecificationParser } from "jinaga";
+
+import { addFactType, addRole, emptyFactTypeMap, emptyRoleMap, getFactTypeId } from "../../src/postgres/maps";
+import { sqlFromFeed } from "../../src/postgres/specification-sql";
+
+// Regression coverage for jinaga-server#179.
+//
+// The issue named two candidate loci for a `Jinaga.User`-given feed returning
+// empty despite matching data: the distribution decision (jinaga.js) and the
+// Postgres feed SQL (this repo, `sqlFromFeed`). These tests pin down the
+// second: the feed SQL generated for a specification whose given is typed
+// `Jinaga.User` is structurally identical to the SQL for the same join shape
+// against any other given type. There is no `Jinaga.User` special-casing in
+// jinaga-server's query generation, so the empty-result trigger does not live
+// here.
+
+function parseSpecification(input: string) {
+    const parser = new SpecificationParser(input);
+    parser.skipWhitespace();
+    return parser.parseSpecification();
+}
+
+function buildMaps(specification: ReturnType<typeof parseSpecification>) {
+    // Assign deterministic type ids in first-seen order so two specifications
+    // with the same shape but different type names produce identical parameter
+    // sequences. Roles get ids offset well past the type ids to avoid overlap.
+    const factTypes = getAllFactTypes(specification).reduce(
+        (f, factType, i) => addFactType(f, factType, i + 1),
+        emptyFactTypeMap());
+    const roleMap = getAllRoles(specification).reduce(
+        (r, role, i) => {
+            const factTypeId = getFactTypeId(factTypes, role.successorType);
+            if (!factTypeId) {
+                return r;
+            }
+            return addRole(r, factTypeId, role.name, i + 100);
+        },
+        emptyRoleMap());
+    return { factTypes, roleMap };
+}
+
+function feedSqlFor(descriptiveString: string, startType: string) {
+    const specification = parseSpecification(descriptiveString);
+    const { factTypes, roleMap } = buildMaps(specification);
+    const feeds = buildFeeds(specification);
+    expect(feeds.length).toBe(1);
+    const start = [dehydrateReference({ type: startType, key: "value" })];
+    const query = sqlFromFeed(feeds[0], start, "public", "", 100, factTypes, roleMap);
+    expect(query).not.toBeNull();
+    return query!;
+}
+
+describe("Jinaga.User-given feed SQL (issue #179)", () => {
+    // The canonical "owned by me" shape: a successor edged to the given user
+    // through a role named `owner`.
+    const userGiven = feedSqlFor(`
+        (user: Jinaga.User) {
+            activity: Networking.Activity [
+                activity->owner: Jinaga.User = user
+            ]
+        }`, "Jinaga.User");
+
+    // The identical join shape rooted at a non-user given.
+    const activityGiven = feedSqlFor(`
+        (activity: Networking.Activity) {
+            log: Networking.ActivityCrmLog [
+                log->activity: Networking.Activity = activity
+            ]
+        }`, "Networking.Activity");
+
+    it("produces a satisfiable, single feed query for a Jinaga.User given", () => {
+        // A satisfiable query is the whole point: a null/empty query here would
+        // be the silent-empty the issue describes. The given's type is loaded
+        // and the predecessor edge on `owner` is generated.
+        expect(userGiven.sql).toContain("f1.fact_type_id = $1 AND f1.hash = $2");
+        expect(userGiven.sql).toContain("public.edge");
+        expect(userGiven.labels.length).toBe(1);
+    });
+
+    it("generates SQL structurally identical to a non-user given of the same shape", () => {
+        // No Jinaga.User special-casing: the two SQL strings match exactly.
+        expect(userGiven.sql).toEqual(activityGiven.sql);
+    });
+
+    it("binds the given type id and hash as the leading parameters, not a constant", () => {
+        // The given fact type participates in the WHERE clause like any other —
+        // it is not dropped or defaulted to 0 for Jinaga.User.
+        const userReference = dehydrateReference({ type: "Jinaga.User", key: "value" });
+        expect(userGiven.parameters[0]).toBe(1);
+        expect(userGiven.parameters[1]).toBe(userReference.hash);
+    });
+});

--- a/test/postgres/userGivenFeedSqlSpec.ts
+++ b/test/postgres/userGivenFeedSqlSpec.ts
@@ -1,6 +1,6 @@
-import { buildFeeds, dehydrateReference, getAllFactTypes, getAllRoles, SpecificationParser } from "jinaga";
+import { buildFeeds, dehydrateReference, getAllFactTypes, getAllRoles, Specification, SpecificationParser } from "jinaga";
 
-import { addFactType, addRole, emptyFactTypeMap, emptyRoleMap, getFactTypeId } from "../../src/postgres/maps";
+import { addFactType, addRole, emptyFactTypeMap, emptyRoleMap, FactTypeMap, getFactTypeId, RoleMap } from "../../src/postgres/maps";
 import { sqlFromFeed } from "../../src/postgres/specification-sql";
 
 // Regression coverage for jinaga-server#179.
@@ -14,79 +14,102 @@ import { sqlFromFeed } from "../../src/postgres/specification-sql";
 // jinaga-server's query generation, so the empty-result trigger does not live
 // here.
 
-function parseSpecification(input: string) {
+function parseSpecification(input: string): Specification {
     const parser = new SpecificationParser(input);
     parser.skipWhitespace();
     return parser.parseSpecification();
 }
 
-function buildMaps(specification: ReturnType<typeof parseSpecification>) {
+function buildMaps(specification: Specification): { factTypes: FactTypeMap; roleMap: RoleMap } {
     // Assign deterministic type ids in first-seen order so two specifications
     // with the same shape but different type names produce identical parameter
-    // sequences. Roles get ids offset well past the type ids to avoid overlap.
-    const factTypes = getAllFactTypes(specification).reduce(
-        (f, factType, i) => addFactType(f, factType, i + 1),
-        emptyFactTypeMap());
-    const roleMap = getAllRoles(specification).reduce(
-        (r, role, i) => {
+    // sequences. Filter the synthetic "Unknown" fact type and "unknown" role
+    // name (matching the other Postgres SQL generator specs) so they cannot
+    // shift the id assignment. Roles get ids offset well past the type ids.
+    const factTypes = getAllFactTypes(specification)
+        .filter(factType => factType !== 'Unknown')
+        .reduce((f, factType, i) => addFactType(f, factType, i + 1), emptyFactTypeMap());
+    const roleMap = getAllRoles(specification)
+        .filter(role => role.name !== 'unknown')
+        .reduce((r, role, i) => {
             const factTypeId = getFactTypeId(factTypes, role.successorType);
             if (!factTypeId) {
                 return r;
             }
             return addRole(r, factTypeId, role.name, i + 100);
-        },
-        emptyRoleMap());
+        }, emptyRoleMap());
     return { factTypes, roleMap };
 }
 
+// Pure: generates the feed SQL for a single-feed specification. All assertions
+// live in the tests (or beforeAll) so a parse/build failure surfaces as a test
+// failure rather than a suite-collection error.
 function feedSqlFor(descriptiveString: string, startType: string) {
     const specification = parseSpecification(descriptiveString);
     const { factTypes, roleMap } = buildMaps(specification);
     const feeds = buildFeeds(specification);
-    expect(feeds.length).toBe(1);
     const start = [dehydrateReference({ type: startType, key: "value" })];
     const query = sqlFromFeed(feeds[0], start, "public", "", 100, factTypes, roleMap);
-    expect(query).not.toBeNull();
-    return query!;
+    return { query, feedCount: feeds.length, factTypes };
 }
 
-describe("Jinaga.User-given feed SQL (issue #179)", () => {
-    // The canonical "owned by me" shape: a successor edged to the given user
-    // through a role named `owner`.
-    const userGiven = feedSqlFor(`
-        (user: Jinaga.User) {
-            activity: Networking.Activity [
-                activity->owner: Jinaga.User = user
-            ]
-        }`, "Jinaga.User");
+// The canonical "owned by me" shape: a successor edged to the given user
+// through a role named `owner`.
+const USER_GIVEN_SPEC = `
+    (user: Jinaga.User) {
+        activity: Networking.Activity [
+            activity->owner: Jinaga.User = user
+        ]
+    }`;
 
-    // The identical join shape rooted at a non-user given.
-    const activityGiven = feedSqlFor(`
-        (activity: Networking.Activity) {
-            log: Networking.ActivityCrmLog [
-                log->activity: Networking.Activity = activity
-            ]
-        }`, "Networking.Activity");
+// The identical join shape rooted at a non-user given.
+const ACTIVITY_GIVEN_SPEC = `
+    (activity: Networking.Activity) {
+        log: Networking.ActivityCrmLog [
+            log->activity: Networking.Activity = activity
+        ]
+    }`;
+
+describe("Jinaga.User-given feed SQL (issue #179)", () => {
+    let userGiven: ReturnType<typeof feedSqlFor>;
+    let activityGiven: ReturnType<typeof feedSqlFor>;
+
+    beforeAll(() => {
+        userGiven = feedSqlFor(USER_GIVEN_SPEC, "Jinaga.User");
+        activityGiven = feedSqlFor(ACTIVITY_GIVEN_SPEC, "Networking.Activity");
+        // Both shapes must reduce to a single feed for the comparison to be
+        // apples-to-apples.
+        expect(userGiven.feedCount).toBe(1);
+        expect(activityGiven.feedCount).toBe(1);
+    });
 
     it("produces a satisfiable, single feed query for a Jinaga.User given", () => {
-        // A satisfiable query is the whole point: a null/empty query here would
-        // be the silent-empty the issue describes. The given's type is loaded
-        // and the predecessor edge on `owner` is generated.
-        expect(userGiven.sql).toContain("f1.fact_type_id = $1 AND f1.hash = $2");
-        expect(userGiven.sql).toContain("public.edge");
-        expect(userGiven.labels.length).toBe(1);
+        // A satisfiable query is the whole point: a null query here would be
+        // the silent-empty the issue describes. The given's type is loaded and
+        // the predecessor edge on `owner` is generated.
+        expect(userGiven.query).not.toBeNull();
+        expect(userGiven.query!.sql).toContain("f1.fact_type_id = $1 AND f1.hash = $2");
+        expect(userGiven.query!.sql).toContain("public.edge");
+        expect(userGiven.query!.labels.length).toBe(1);
     });
 
     it("generates SQL structurally identical to a non-user given of the same shape", () => {
         // No Jinaga.User special-casing: the two SQL strings match exactly.
-        expect(userGiven.sql).toEqual(activityGiven.sql);
+        expect(userGiven.query).not.toBeNull();
+        expect(activityGiven.query).not.toBeNull();
+        expect(userGiven.query!.sql).toEqual(activityGiven.query!.sql);
     });
 
-    it("binds the given type id and hash as the leading parameters, not a constant", () => {
+    it("binds the given type id (from the fact-type map) and hash as the leading parameters", () => {
         // The given fact type participates in the WHERE clause like any other —
-        // it is not dropped or defaulted to 0 for Jinaga.User.
+        // it is not dropped or defaulted to a constant for Jinaga.User. Derive
+        // the expected id from the map built for this spec so the assertion is
+        // not coupled to getAllFactTypes ordering.
         const userReference = dehydrateReference({ type: "Jinaga.User", key: "value" });
-        expect(userGiven.parameters[0]).toBe(1);
-        expect(userGiven.parameters[1]).toBe(userReference.hash);
+        const expectedTypeId = getFactTypeId(userGiven.factTypes, "Jinaga.User");
+        expect(expectedTypeId).toBeDefined();
+        expect(userGiven.query).not.toBeNull();
+        expect(userGiven.query!.parameters[0]).toBe(expectedTypeId);
+        expect(userGiven.query!.parameters[1]).toBe(userReference.hash);
     });
 });


### PR DESCRIPTION
## Summary

Addresses issue #179. That issue named two candidate loci for a one-shot `query()` against a `Jinaga.User`-typed given returning empty despite matching data:

1. the distribution decision computation, and
2. the Postgres feed SQL in this repo (`sqlFromFeed` / `feed()`).

This PR pins down locus **2**: jinaga-server's feed SQL is provably type-agnostic, so the empty-result trigger does not live here. The actual one-shot contract fix lives in jinaga.js.

## What this changes

Adds `test/postgres/userGivenFeedSqlSpec.ts`, which asserts that the feed SQL generated for the canonical "owned by me" shape:

```
(user: Jinaga.User) {
    activity: Networking.Activity [ activity->owner: Jinaga.User = user ]
}
```

is **byte-for-byte identical** to the SQL for the same join shape against a non-user given:

```
(activity: Networking.Activity) {
    log: Networking.ActivityCrmLog [ log->activity: Networking.Activity = activity ]
}
```

and that the given's fact type id and hash are bound as the leading query parameters — i.e. the `Jinaga.User` given participates in the `WHERE` clause exactly like any other type, with no special-casing, defaulting, or dropped filter.

## Investigation notes

- The `WHERE f1.fact_type_id = $1 AND f1.hash = $2` clause and the predecessor-edge join are generated identically for both givens.
- `getAllFactTypes` includes the given label types, so `Jinaga.User` is loaded into the fact-type map — the read/feed satisfiability guard (`postgres-store.ts`) is not tripped by a missing type.
- The server's `POST /feeds` already returns a complete, actionable per-feed distribution decision (`feed`, `decision`, `code`, `reason`), and the one-shot `/read` endpoint already throws `Forbidden` with the denial reason.

The remaining contract gap — a one-shot `query()` silently returning empty on a **structural** distribution denial instead of throwing — is in jinaga.js, fixed in jinaga/jinaga.js#228 (`query()` now throws `DistributionDeniedError` on a structural denial by default, in every mode).

## Tests

New spec passes; project type-check (`tsconfig.test.json`) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VokiTvx83cazRWw8zcDAzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VokiTvx83cazRWw8zcDAzD)_