### PR TITLE
Close the error-to-HTTP-status mapping gaps in the router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "csv-stringify": "^6.6.0",
         "express": "^4.21.2",
-        "jinaga": "^6.11.1",
+        "jinaga": "^6.11.3",
         "pg": "^8.13.1"
       },
       "devDependencies": {
@@ -3955,9 +3955,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.11.1.tgz",
-      "integrity": "sha512-frkq+ksi+BkWhqly6yyKZKlud8CQ1aNFOe0kUH/uVbf4RYzXWfb2Njs4HjW9Bqb1MKvRYSxenRoUQHQ3zUrPFQ==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.11.3.tgz",
+      "integrity": "sha512-YkX8t7bGgURvtX0DVO4d+0lfX90A6MruUBYPdbQqA9hzfsDTsG8pjZ0iW1WfR7KFszrIEzw8HLV0c51RukXr3A==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "csv-stringify": "^6.6.0",
     "express": "^4.21.2",
-    "jinaga": "^6.11.1",
+    "jinaga": "^6.11.3",
     "pg": "^8.13.1"
   }
 }

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -58,7 +58,7 @@ function getOrStream<U>(
                 .then(response => {
                     if (!response) {
                         console.log(`[HttpConnection:${connectionId}] Stream method returned null - sending 404`);
-                        res.sendStatus(404);
+                        sendRouteMiss(res);
                         next();
                     }
                     else {
@@ -156,7 +156,7 @@ function getOrStream<U>(
                 .then(response => {
                     if (!response) {
                         console.log(`[HttpConnection:${connectionId}] Get method returned null - sending 404`);
-                        res.sendStatus(404);
+                        sendRouteMiss(res);
                         next();
                     }
                     else {
@@ -199,9 +199,14 @@ function post<T, U>(
 ): Handler {
     return (req, res, next) => {
         const user = <RequestUser>(req as any).user;
-        const message = parse(req.body);
+        const parsed = parseRequestInput(() => parse(req.body), req, res, next);
+        if (!parsed.ok) {
+            return;
+        }
+        const message = parsed.value;
         if (!message) {
-            throw new Error('Ensure that you have called app.use(express.json()).');
+            handleError(new Invalid(MISSING_BODY), req, res, next);
+            return;
         }
         method(user, message, req.params)
             .then(response => {
@@ -224,8 +229,11 @@ function postCreate<T>(
 ): Handler {
     return (req, res, next) => {
         const user = <RequestUser>(req as any).user;
-        const message = parse(req);
-        method(user, message)
+        const parsed = parseRequestInput(() => parse(req), req, res, next);
+        if (!parsed.ok) {
+            return;
+        }
+        method(user, parsed.value)
             .then(_ => {
                 res.sendStatus(201);
                 next();
@@ -237,10 +245,13 @@ function postCreate<T>(
 function postStringCreate(method: (user: RequestUser, message: string) => Promise<void>): Handler {
     return (req, res, next) => {
         const user = <RequestUser>(req as any).user;
-        const input = parseString(req.body);
-        if (!input || typeof (input) !== 'string') {
-            res.type("text");
-            res.status(500).send('Expected Content-Type text/plain. Ensure that you have called app.use(express.text()).');
+        const parsed = parseRequestInput(() => parseString(req.body), req, res, next);
+        if (!parsed.ok) {
+            return;
+        }
+        const input = parsed.value;
+        if (!input) {
+            handleError(new Invalid(MISSING_TEXT_BODY), req, res, next);
         }
         else {
             method(user, input)
@@ -261,10 +272,13 @@ function postReadWithStreaming(
 ): Handler {
     return (req, res, next) => {
         const user = <RequestUser>(req as any).user;
-        const input = parseString(req.body);
-        if (!input || typeof (input) !== 'string') {
-            res.type("text");
-            res.status(500).send('Expected Content-Type text/plain. Ensure that you have called app.use(express.text()).');
+        const parsed = parseRequestInput(() => parseString(req.body), req, res, next);
+        if (!parsed.ok) {
+            return;
+        }
+        const input = parsed.value;
+        if (!input) {
+            handleError(new Invalid(MISSING_TEXT_BODY), req, res, next);
         }
         else {
             // Check if Accept header explicitly prefers a specific format
@@ -313,7 +327,7 @@ function inputSaveMessage(req: Request): GraphSource {
             read: async (onEnvelopes) => {
                 const message = parseSaveMessage(req.body);
                 if (!message) {
-                    throw new Error('Ensure that you have called app.use(express.json()).');
+                    throw new Invalid(MISSING_JSON_BODY);
                 }
                 await onEnvelopes(message.facts.map(fact => ({
                     fact: fact,
@@ -550,11 +564,19 @@ export class HttpRouter {
             }
 
             const userIdentity = serializeUserIdentity(user);
-            await this.authorization.save(userIdentity, factRecords
+            const envelopes: FactEnvelope[] = factRecords
                 .map(fact => ({
                     fact: fact,
                     signatures: []
-                })));
+                }));
+            try {
+                await this.authorization.save(userIdentity, envelopes);
+            } catch (error) {
+                // /write reaches the same authorization path as /save, so it
+                // needs the same translation of predecessor-resolution
+                // failures into a diagnosable 4xx (issue #182 finding 2).
+                throw toSaveAuthorizationError(error, envelopes);
+            }
         });
     }
 
@@ -988,6 +1010,13 @@ export class FeedNotFound extends Error {
     }
 }
 
+// Both message shapes below are matched by prose, because jinaga reports a
+// missing predecessor as a plain Error. That is fragile: an upstream wording
+// change silently turns these back into 500s (issue #182 finding 5). The
+// end-to-end cases in test/http/errorStatusMappingSpec.ts drive the real
+// AuthorizationEngine so that drift fails the build. Replace the patterns
+// with instanceof checks once jinaga.js#234 lands a typed error.
+
 // Authorization rule evaluation reports a missing predecessor as a plain
 // Error of this shape (see authorizationRules.ts / specification-runner.ts
 // in jinaga). It surfaces when the client's save request didn't include the
@@ -995,23 +1024,93 @@ export class FeedNotFound extends Error {
 // instead of an opaque 500 (issue #175).
 const FACT_NOT_DEFINED_PATTERN = /^The fact (\S+):(\S+) is not defined\.$/;
 
+// The topological sort in jinaga's AuthorizationEngine.authorizeFacts reports
+// the same underlying condition — a predecessor present in neither the batch
+// nor storage — with different wording, and names the successors it could not
+// sort rather than the predecessor it could not find. It never matched the
+// pattern above, so it fell through to a bare 500 (issue #182 finding 1).
+const UNRESOLVED_PREDECESSOR_PATTERN = /^Cannot authorize (\d+ facts?) of type (.+?): one or more predecessors could not be resolved\./;
+
 function toSaveAuthorizationError(error: any, envelopes: FactEnvelope[]): any {
-    if (error instanceof Error) {
-        const match = FACT_NOT_DEFINED_PATTERN.exec(error.message);
-        if (match) {
-            const [, factType, factHash] = match;
-            const factTypesInBatch = Array.from(new Set(envelopes.map(e => e.fact.type))).join(", ");
-            Trace.warn(
-                `Save authorization could not resolve predecessor ${factType}:${factHash} ` +
-                `among ${envelopes.length} fact(s) in the request (types: ${factTypesInBatch}).`
-            );
-            return new Invalid(
-                `The fact ${factType}:${factHash} is required to authorize this save but was not included in the request. ` +
-                `Ensure the full closure of predecessors needed by your authorization rules is sent together.`
-            );
-        }
+    if (!(error instanceof Error)) {
+        return error;
     }
+
+    const describeBatch = () => {
+        const factTypesInBatch = Array.from(new Set(envelopes.map(e => e.fact.type))).join(", ");
+        return `${envelopes.length} fact(s) in the request (types: ${factTypesInBatch})`;
+    };
+
+    const notDefined = FACT_NOT_DEFINED_PATTERN.exec(error.message);
+    if (notDefined) {
+        const [, factType, factHash] = notDefined;
+        Trace.warn(
+            `Save authorization could not resolve predecessor ${factType}:${factHash} ` +
+            `among ${describeBatch()}.`
+        );
+        return new Invalid(
+            `The fact ${factType}:${factHash} is required to authorize this save but was not included in the request. ` +
+            `Ensure the full closure of predecessors needed by your authorization rules is sent together.`
+        );
+    }
+
+    const unresolved = UNRESOLVED_PREDECESSOR_PATTERN.exec(error.message);
+    if (unresolved) {
+        const [, count, unresolvedTypes] = unresolved;
+        Trace.warn(
+            `Save authorization could not resolve the predecessors of ${count} of type ${unresolvedTypes} ` +
+            `among ${describeBatch()}.`
+        );
+        return new Invalid(
+            `${count} of type ${unresolvedTypes} could not be authorized because one or more predecessors ` +
+            `were not found in storage and were not included in the request. ` +
+            `Ensure the full closure of predecessors needed by your authorization rules is sent together.`
+        );
+    }
+
     return error;
+}
+
+// post() serves both a JSON route (/load) and a text route (/feeds), so its
+// message names no particular parser; the single-content-type entry points
+// keep the specific hint they have always given.
+const MISSING_BODY = 'The request body is empty or could not be read. Ensure that the body parser for this Content-Type is registered.';
+const MISSING_JSON_BODY = 'Ensure that you have called app.use(express.json()).';
+const MISSING_TEXT_BODY = 'Expected Content-Type text/plain. Ensure that you have called app.use(express.text()).';
+
+// A request body that fails to parse is a client error. Both this module's
+// parseString and jinaga's message parsers signal that by throwing
+// synchronously from the handler, where Express hands it to its default error
+// handler and reports 500. Classify parse failures as Invalid so handleError
+// renders a 400 (issue #182 finding 3).
+function toInvalidInput(error: any): Invalid {
+    if (error instanceof Invalid) {
+        return error;
+    }
+    return new Invalid(error instanceof Error ? error.message : String(error));
+}
+
+function parseRequestInput<T>(
+    parse: () => T,
+    req: Request,
+    res: Response,
+    next: NextFunction
+): { ok: true, value: T } | { ok: false } {
+    try {
+        return { ok: true, value: parse() };
+    } catch (error) {
+        handleError(toInvalidInput(error), req, res, next);
+        return { ok: false };
+    }
+}
+
+// A route miss (no :hash in the URL) is a 404 just like a feed-cache miss,
+// but for a different reason. Send a machine-readable body so a client can
+// always tell "wrong URL" from "re-subscribe via POST /feeds" (issue #182
+// finding 6); handleError sends "feed_not_found" for the latter.
+function sendRouteMiss(res: Response) {
+    res.type("text");
+    res.status(404).send("not_found");
 }
 
 function handleError(error: any, req: Request, res: Response, next: NextFunction) {
@@ -1029,9 +1128,13 @@ function handleError(error: any, req: Request, res: Response, next: NextFunction
         res.type("text");
         res.status(400).send(error.message);
     } else {
+        // Classification above is an allow-list, so anything reaching here is
+        // unclassified — including genuine internal failures whose message can
+        // name internal hosts or credentials. Keep the detail in the trace and
+        // send a generic body to the caller (issue #182 finding 4).
         Trace.error(`Error: ${error.message} (Path: ${requestPath})`);
         res.type("text");
-        res.status(500).send(error.message);
+        res.status(500).send("Internal server error");
     }
     next();
 }

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -205,7 +205,7 @@ function post<T, U>(
         }
         const message = parsed.value;
         if (!message) {
-            handleError(new Invalid(MISSING_BODY), req, res, next);
+            handleError(new Invalid(`${MISSING_BODY} ${describeContentType(req)}`), req, res, next);
             return;
         }
         method(user, message, req.params)
@@ -361,7 +361,9 @@ function outputReadResults(
         .catch(error => {
             console.error('Error in outputReadResults:', error);
             if (!res.headersSent) {
-                res.status(500).send('Internal server error');
+                // Without an explicit type, res.send of a string makes Express
+                // infer text/html and label an error body as markup.
+                res.type("text").status(500).send('Internal server error');
             }
         });
 }
@@ -1087,9 +1089,18 @@ function toInvalidInput(error: any): Invalid {
 function parseTextBody(req: Request): string {
     const body = req.body;
     if (typeof body !== 'string' || !body) {
-        throw new Invalid(MISSING_TEXT_BODY);
+        throw new Invalid(`${MISSING_TEXT_BODY} ${describeContentType(req)}`);
     }
     return body;
+}
+
+// Naming what arrived turns "check your setup" into something the caller can
+// act on without guessing which end is misconfigured.
+function describeContentType(req: Request): string {
+    const contentType = req.get('Content-Type');
+    return contentType
+        ? `Received Content-Type: ${contentType}.`
+        : `No Content-Type header was received.`;
 }
 
 function parseRequestInput<T>(
@@ -1117,6 +1128,9 @@ function sendRouteMiss(res: Response) {
 
 function handleError(error: any, req: Request, res: Response, next: NextFunction) {
     const requestPath = req.path;
+    // Error bodies are plain text built partly from client-supplied input, so
+    // stop a browser from sniffing one as markup.
+    res.set("X-Content-Type-Options", "nosniff");
     if (error instanceof FeedNotFound) {
         Trace.warn(`Feed not found: ${error.feedHash} (Path: ${requestPath})`);
         res.type("text");

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -245,22 +245,16 @@ function postCreate<T>(
 function postStringCreate(method: (user: RequestUser, message: string) => Promise<void>): Handler {
     return (req, res, next) => {
         const user = <RequestUser>(req as any).user;
-        const parsed = parseRequestInput(() => parseString(req.body), req, res, next);
+        const parsed = parseRequestInput(() => parseTextBody(req), req, res, next);
         if (!parsed.ok) {
             return;
         }
-        const input = parsed.value;
-        if (!input) {
-            handleError(new Invalid(MISSING_TEXT_BODY), req, res, next);
-        }
-        else {
-            method(user, input)
-                .then(_ => {
-                    res.sendStatus(201);
-                    next();
-                })
-                .catch(error => handleError(error, req, res, next));
-        }
+        method(user, parsed.value)
+            .then(_ => {
+                res.sendStatus(201);
+                next();
+            })
+            .catch(error => handleError(error, req, res, next));
     };
 }
 
@@ -272,32 +266,27 @@ function postReadWithStreaming(
 ): Handler {
     return (req, res, next) => {
         const user = <RequestUser>(req as any).user;
-        const parsed = parseRequestInput(() => parseString(req.body), req, res, next);
+        const parsed = parseRequestInput(() => parseTextBody(req), req, res, next);
         if (!parsed.ok) {
             return;
         }
-        const input = parsed.value;
-        if (!input) {
-            handleError(new Invalid(MISSING_TEXT_BODY), req, res, next);
-        }
-        else {
-            // Check if Accept header explicitly prefers a specific format
-            const acceptHeader = req.get('Accept');
-            let acceptType: string = 'text/plain'; // Default for backward compatibility
 
-            if (acceptHeader && acceptHeader !== '*/*') {
-                // Only use req.accepts() when there's a specific preference
-                const preferredType = req.accepts(['text/csv', 'application/x-ndjson', 'application/json', 'text/plain']);
-                acceptType = preferredType ? String(preferredType) : 'text/plain';
-            }
-            
-            method(user, input, acceptType)
-                .then(({resultStream, csvMetadata}) => {
-                    outputReadResults(resultStream, res, acceptType, csvMetadata);
-                    next();
-                })
-                .catch(error => handleError(error, req, res, next));
+        // Check if Accept header explicitly prefers a specific format
+        const acceptHeader = req.get('Accept');
+        let acceptType: string = 'text/plain'; // Default for backward compatibility
+
+        if (acceptHeader && acceptHeader !== '*/*') {
+            // Only use req.accepts() when there's a specific preference
+            const preferredType = req.accepts(['text/csv', 'application/x-ndjson', 'application/json', 'text/plain']);
+            acceptType = preferredType ? String(preferredType) : 'text/plain';
         }
+
+        method(user, parsed.value, acceptType)
+            .then(({resultStream, csvMetadata}) => {
+                outputReadResults(resultStream, res, acceptType, csvMetadata);
+                next();
+            })
+            .catch(error => handleError(error, req, res, next));
     };
 }
 
@@ -1088,6 +1077,19 @@ function toInvalidInput(error: any): Invalid {
         return error;
     }
     return new Invalid(error instanceof Error ? error.message : String(error));
+}
+
+// /read and /write accept text/plain only, so every unreadable body there has
+// the same cause and deserves the same actionable hint. Checking req.body here
+// rather than deferring to parseString keeps a missing body parser — the common
+// misconfiguration — from being reported with parseString's generic
+// content-type message.
+function parseTextBody(req: Request): string {
+    const body = req.body;
+    if (typeof body !== 'string' || !body) {
+        throw new Invalid(MISSING_TEXT_BODY);
+    }
+    return body;
 }
 
 function parseRequestInput<T>(

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -1095,12 +1095,20 @@ function parseTextBody(req: Request): string {
 }
 
 // Naming what arrived turns "check your setup" into something the caller can
-// act on without guessing which end is misconfigured.
+// act on without guessing which end is misconfigured. The value is echoed from
+// the request, so cap it: a real content type is short, and the body should
+// not grow with whatever the caller chose to send.
+const MAX_ECHOED_CONTENT_TYPE = 80;
+
 function describeContentType(req: Request): string {
     const contentType = req.get('Content-Type');
-    return contentType
-        ? `Received Content-Type: ${contentType}.`
-        : `No Content-Type header was received.`;
+    if (!contentType) {
+        return `No Content-Type header was received.`;
+    }
+    const echoed = contentType.length > MAX_ECHOED_CONTENT_TYPE
+        ? `${contentType.substring(0, MAX_ECHOED_CONTENT_TYPE)}…`
+        : contentType;
+    return `Received Content-Type: ${echoed}.`;
 }
 
 function parseRequestInput<T>(
@@ -1126,6 +1134,24 @@ function sendRouteMiss(res: Response) {
     res.status(404).send("not_found");
 }
 
+// These bodies are diagnostics, not markup, but they quote client-supplied
+// text: a Content-Type header, a fact type named in a parse failure. The
+// response is text/plain and marked nosniff, yet that is the content type
+// saying so — neutralize the characters that could start markup here, at the
+// one place every error body is written, so the guarantee does not rest on a
+// header a proxy or a later edit could change. Quotes are left alone: they
+// only matter inside a tag, which escaping '<' already prevents, and messages
+// quote identifiers routinely.
+const HTML_META_CHARACTERS: { [character: string]: string } = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;"
+};
+
+function sanitizeErrorBody(message: string): string {
+    return message.replace(/[&<>]/g, character => HTML_META_CHARACTERS[character]);
+}
+
 function handleError(error: any, req: Request, res: Response, next: NextFunction) {
     const requestPath = req.path;
     // Error bodies are plain text built partly from client-supplied input, so
@@ -1138,11 +1164,11 @@ function handleError(error: any, req: Request, res: Response, next: NextFunction
     } else if (error instanceof Forbidden) {
         Trace.warn(`Forbidden: ${error.message} (Path: ${requestPath})`);
         res.type("text");
-        res.status(403).send(error.message);
+        res.status(403).send(sanitizeErrorBody(error.message));
     } else if (error instanceof Invalid) {
         Trace.warn(`Invalid: ${error.message} (Path: ${requestPath})`);
         res.type("text");
-        res.status(400).send(error.message);
+        res.status(400).send(sanitizeErrorBody(error.message));
     } else {
         // Classification above is an allow-list, so anything reaching here is
         // unclassified — including genuine internal failures whose message can

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -22,6 +22,7 @@ import {
     LoadResponse,
     parseLoadMessage,
     parseSaveMessage,
+    PredecessorNotResolvedError,
     ProfileMessage,
     ProjectedResult,
     ReferencesByName,
@@ -1005,22 +1006,18 @@ export class FeedNotFound extends Error {
 // missing predecessor as a plain Error. That is fragile: an upstream wording
 // change silently turns these back into 500s (issue #182 finding 5). The
 // end-to-end cases in test/http/errorStatusMappingSpec.ts drive the real
-// AuthorizationEngine so that drift fails the build. Replace the patterns
-// with instanceof checks once jinaga.js#234 lands a typed error.
+// AuthorizationEngine so that drift fails the build.
+//
+// jinaga 6.11.3 landed the typed errors of jinaga.js#234, so the topological
+// sort's failure is now an instanceof check below. One prose pattern remains:
+// specification-runner still reports its missing fact as a plain Error.
 
 // Authorization rule evaluation reports a missing predecessor as a plain
-// Error of this shape (see authorizationRules.ts / specification-runner.ts
-// in jinaga). It surfaces when the client's save request didn't include the
-// full closure of facts a rule needs to walk. Map it to a diagnosable 4xx
-// instead of an opaque 500 (issue #175).
+// Error of this shape (specification-runner.ts in jinaga, still untyped as of
+// 6.11.3). It surfaces when the client's save request didn't include the full
+// closure of facts a rule needs to walk. Map it to a diagnosable 4xx instead
+// of an opaque 500 (issue #175).
 const FACT_NOT_DEFINED_PATTERN = /^The fact (\S+):(\S+) is not defined\.$/;
-
-// The topological sort in jinaga's AuthorizationEngine.authorizeFacts reports
-// the same underlying condition — a predecessor present in neither the batch
-// nor storage — with different wording, and names the successors it could not
-// sort rather than the predecessor it could not find. It never matched the
-// pattern above, so it fell through to a bare 500 (issue #182 finding 1).
-const UNRESOLVED_PREDECESSOR_PATTERN = /^Cannot authorize (\d+ facts?) of type (.+?): one or more predecessors could not be resolved\./;
 
 function toSaveAuthorizationError(error: any, envelopes: FactEnvelope[]): any {
     if (!(error instanceof Error)) {
@@ -1032,6 +1029,36 @@ function toSaveAuthorizationError(error: any, envelopes: FactEnvelope[]): any {
         return `${envelopes.length} fact(s) in the request (types: ${factTypesInBatch})`;
     };
 
+    // The batch named a predecessor that is in neither the batch nor storage,
+    // so the topological sort could never reach the facts that depend on it.
+    // A client data problem, not a server fault (issue #182 finding 1).
+    if (error instanceof PredecessorNotResolvedError) {
+        const missing = error.missingPredecessors.map(r => `${r.type}:${r.hash}`);
+        const unresolved = error.unresolvedFacts.map(r => `${r.type}:${r.hash}`);
+        Trace.warn(
+            `Save authorization could not resolve ${missing.length} predecessor(s) [${missing.join(", ")}] ` +
+            `needed by ${unresolved.length} fact(s) [${unresolved.join(", ")}] among ${describeBatch()}.`
+        );
+        const advice = `Send the full closure of predecessors together, or commit the predecessors first.`;
+        if (missing.length === 1) {
+            return new Invalid(
+                `The fact ${missing[0]} is named as a predecessor, but it was not found in storage ` +
+                `and was not included in the request. ${advice}`
+            );
+        }
+        if (missing.length > 1) {
+            return new Invalid(
+                `${missing.length} facts are named as predecessors, but they were not found in storage ` +
+                `and were not included in the request: ${missing.join(", ")}. ${advice}`
+            );
+        }
+        // The engine could not attribute the failure to specific references.
+        return new Invalid(
+            `${unresolved.length} fact(s) could not be authorized because one or more predecessors ` +
+            `were not found in storage and were not included in the request. ${advice}`
+        );
+    }
+
     const notDefined = FACT_NOT_DEFINED_PATTERN.exec(error.message);
     if (notDefined) {
         const [, factType, factHash] = notDefined;
@@ -1041,20 +1068,6 @@ function toSaveAuthorizationError(error: any, envelopes: FactEnvelope[]): any {
         );
         return new Invalid(
             `The fact ${factType}:${factHash} is required to authorize this save but was not included in the request. ` +
-            `Ensure the full closure of predecessors needed by your authorization rules is sent together.`
-        );
-    }
-
-    const unresolved = UNRESOLVED_PREDECESSOR_PATTERN.exec(error.message);
-    if (unresolved) {
-        const [, count, unresolvedTypes] = unresolved;
-        Trace.warn(
-            `Save authorization could not resolve the predecessors of ${count} of type ${unresolvedTypes} ` +
-            `among ${describeBatch()}.`
-        );
-        return new Invalid(
-            `${count} of type ${unresolvedTypes} could not be authorized because one or more predecessors ` +
-            `were not found in storage and were not included in the request. ` +
             `Ensure the full closure of predecessors needed by your authorization rules is sent together.`
         );
     }

--- a/test/http/errorStatusMappingSpec.ts
+++ b/test/http/errorStatusMappingSpec.ts
@@ -10,12 +10,14 @@ import {
     DistributionRules,
     FactEnvelope,
     FactManager,
+    FactReference,
     FeedCache,
     Invalid,
     MemoryStore,
     NetworkNoOp,
     ObservableSource,
     PassThroughFork,
+    PredecessorNotResolvedError,
     User
 } from "jinaga";
 
@@ -116,43 +118,49 @@ async function captureError(action: () => Promise<unknown>): Promise<any> {
     throw new Error("Expected the operation to fail, but it succeeded.");
 }
 
-// Issue #182 findings 1 and 2. The translation in router.ts matches jinaga's
-// exact English wording, so these cases drive the real AuthorizationEngine
-// rather than a hand-written message: if upstream rewords the error, the
-// pattern stops matching and these tests fail instead of the classification
-// silently regressing to a 500 in production. Replace with instanceof checks
-// once jinaga.js#234 lands a typed error.
+// Issue #182 findings 1 and 2. These drive the real AuthorizationEngine rather
+// than a hand-written message, so the classification is pinned to what jinaga
+// actually throws. That mattered concretely: the original version of this
+// translation matched the engine's prose, and 6.11.3 reworded it one release
+// later — these tests failed rather than letting the 400 regress to a 500 in
+// production. The unresolved-predecessor path is now an instanceof check on
+// the typed error jinaga.js#234 introduced.
 describe("save authorization error translation", () => {
-    it("reports an unresolved predecessor from the real engine as a plain Error", async () => {
+    it("reports an unresolved predecessor from the real engine as a typed error", async () => {
         const { authorization, owner } = await createHarness();
 
         const error = await captureError(() =>
             authorization.save(ownerIdentity, unclosedBatch(owner)));
 
-        // Establishes the untranslated baseline: jinaga signals this client
-        // data problem with a bare Error, which handleError would map to 500.
-        expect(error).toBeInstanceOf(Error);
+        // The untranslated baseline: still not an Invalid, so handleError alone
+        // would map it to 500 — but now it carries the structured detail the
+        // translation reads instead of parsing prose.
+        expect(error).toBeInstanceOf(PredecessorNotResolvedError);
         expect(error).not.toBeInstanceOf(Invalid);
-        expect(error.message).toContain("one or more predecessors could not be resolved");
+        expect(error.missingPredecessors.map((r: FactReference) => r.type)).toContain(Workspace.Type);
+        expect(error.unresolvedFacts.map((r: FactReference) => r.type)).toContain(Application.Type);
     });
 
-    it("translates the unresolved-predecessor shape to Invalid on /save", async () => {
+    it("translates the unresolved predecessor to Invalid on /save", async () => {
         const { router, owner } = await createHarness();
 
         const error = await captureError(() =>
             (router as any).save(requestUser, graphSourceOf(unclosedBatch(owner))));
 
         expect(error).toBeInstanceOf(Invalid);
-        expect(error.message).toContain(Application.Type);
-        expect(error.message).toContain("were not found in storage and were not included in the request");
+        // Names the predecessor that is actually missing — the structured
+        // fields make this possible, where the prose match could only report
+        // the successors that failed to sort.
+        expect(error.message).toContain(Workspace.Type);
+        expect(error.message).toContain("was not found in storage and was not included in the request");
     });
 
-    it("translates the unresolved-predecessor shape to Invalid on /write", async () => {
+    it("translates the unresolved predecessor to Invalid on /write", async () => {
         // The declaration grammar /write accepts cannot express a dangling
         // predecessor, so the engine error is captured from the reachable
         // /save path and replayed here. The route still needs the translation:
         // it makes the same authorization call, and this keeps both routes
-        // tracking one upstream wording.
+        // reading one upstream error type.
         const { authorization, owner } = await createHarness();
         const engineError = await captureError(() =>
             authorization.save(ownerIdentity, unclosedBatch(owner)));
@@ -165,7 +173,7 @@ describe("save authorization error translation", () => {
         const error = await captureError(() => (router as any).write(requestUser, declaration));
 
         expect(error).toBeInstanceOf(Invalid);
-        expect(error.message).toContain("were not found in storage and were not included in the request");
+        expect(error.message).toContain("was not found in storage and was not included in the request");
     });
 
     it("still translates the authorization-rule shape fixed by issue #175", async () => {

--- a/test/http/errorStatusMappingSpec.ts
+++ b/test/http/errorStatusMappingSpec.ts
@@ -1,0 +1,268 @@
+import express from "express";
+import { AddressInfo } from "net";
+import { Server } from "http";
+
+import {
+    Authorization,
+    AuthorizationRules,
+    buildModel,
+    dehydrateFact,
+    DistributionRules,
+    FactEnvelope,
+    FactManager,
+    FeedCache,
+    Invalid,
+    MemoryStore,
+    NetworkNoOp,
+    ObservableSource,
+    PassThroughFork,
+    User
+} from "jinaga";
+
+import { AuthorizationKeystore, SubscriptionAuthorizer } from "../../src/authorization/authorization-keystore";
+import { HttpRouter, RequestUser } from "../../src/http/router";
+import { MemoryKeystore } from "../../src/memory/memory-keystore";
+
+class Workspace {
+    static Type = "ErrorStatus.Workspace" as const;
+    public type = Workspace.Type;
+    constructor(public owner: User, public identifier: string) { }
+}
+
+class Application {
+    static Type = "ErrorStatus.Application" as const;
+    public type = Application.Type;
+    constructor(public workspace: Workspace, public name: string) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Workspace, w => w.predecessor("owner", User))
+    .type(Application, a => a.predecessor("workspace", Workspace))
+);
+
+const ownerIdentity = { provider: "mock", id: "owner" };
+
+const requestUser: RequestUser = {
+    provider: ownerIdentity.provider,
+    id: ownerIdentity.id,
+    profile: {} as any
+};
+
+async function createHarness() {
+    const store = new MemoryStore();
+    const keystore = new MemoryKeystore();
+    const ownerFact = await keystore.getOrCreateUserFact(ownerIdentity);
+    const owner = new User(ownerFact.fields.publicKey);
+
+    const factManager = new FactManager(
+        new PassThroughFork(store),
+        new ObservableSource(store),
+        store,
+        new NetworkNoOp(),
+        []
+    );
+
+    const authorizationRules = new AuthorizationRules(model)
+        .any(User.Type)
+        .any(Workspace.Type)
+        .type(Application, app => app.workspace.owner);
+    const authorization = new AuthorizationKeystore(
+        factManager, store, keystore, authorizationRules, new DistributionRules([]));
+    const router = new HttpRouter(factManager, authorization, new FeedCache(), "*");
+
+    return { store, authorization, router, owner };
+}
+
+// A batch holding a successor whose predecessors are in neither the batch nor
+// storage. jinaga's AuthorizationEngine detects this in its topological sort
+// and reports it as a plain Error.
+function unclosedBatch(owner: User): FactEnvelope[] {
+    const records = dehydrateFact(new Application(new Workspace(owner, "workspace-1"), "application-1"));
+    return records
+        .filter(fact => fact.type === Application.Type)
+        .map(fact => ({ fact, signatures: [] }));
+}
+
+function graphSourceOf(envelopes: FactEnvelope[]) {
+    return {
+        read: async (onEnvelopes: (envelopes: FactEnvelope[]) => Promise<void>) => {
+            await onEnvelopes(envelopes);
+        }
+    };
+}
+
+// A router whose only job is to reject the authorization call with a chosen
+// error, so the translation can be exercised for a route whose input grammar
+// cannot provoke the error on its own.
+function createRouterWithFailingSave(error: Error): HttpRouter {
+    const store = new MemoryStore();
+    const factManager = new FactManager(
+        new PassThroughFork(store), new ObservableSource(store), store, new NetworkNoOp(), []);
+    const keystore = new MemoryKeystore();
+    const authorization = {
+        getOrCreateUserFact: (identity: any) => keystore.getOrCreateUserFact(identity),
+        save: () => Promise.reject(error)
+    } as unknown as Authorization & SubscriptionAuthorizer;
+    return new HttpRouter(factManager, authorization, new FeedCache(), "*");
+}
+
+async function captureError(action: () => Promise<unknown>): Promise<any> {
+    try {
+        await action();
+    } catch (error) {
+        return error;
+    }
+    throw new Error("Expected the operation to fail, but it succeeded.");
+}
+
+// Issue #182 findings 1 and 2. The translation in router.ts matches jinaga's
+// exact English wording, so these cases drive the real AuthorizationEngine
+// rather than a hand-written message: if upstream rewords the error, the
+// pattern stops matching and these tests fail instead of the classification
+// silently regressing to a 500 in production. Replace with instanceof checks
+// once jinaga.js#234 lands a typed error.
+describe("save authorization error translation", () => {
+    it("reports an unresolved predecessor from the real engine as a plain Error", async () => {
+        const { authorization, owner } = await createHarness();
+
+        const error = await captureError(() =>
+            authorization.save(ownerIdentity, unclosedBatch(owner)));
+
+        // Establishes the untranslated baseline: jinaga signals this client
+        // data problem with a bare Error, which handleError would map to 500.
+        expect(error).toBeInstanceOf(Error);
+        expect(error).not.toBeInstanceOf(Invalid);
+        expect(error.message).toContain("one or more predecessors could not be resolved");
+    });
+
+    it("translates the unresolved-predecessor shape to Invalid on /save", async () => {
+        const { router, owner } = await createHarness();
+
+        const error = await captureError(() =>
+            (router as any).save(requestUser, graphSourceOf(unclosedBatch(owner))));
+
+        expect(error).toBeInstanceOf(Invalid);
+        expect(error.message).toContain(Application.Type);
+        expect(error.message).toContain("were not found in storage and were not included in the request");
+    });
+
+    it("translates the unresolved-predecessor shape to Invalid on /write", async () => {
+        // The declaration grammar /write accepts cannot express a dangling
+        // predecessor, so the engine error is captured from the reachable
+        // /save path and replayed here. The route still needs the translation:
+        // it makes the same authorization call, and this keeps both routes
+        // tracking one upstream wording.
+        const { authorization, owner } = await createHarness();
+        const engineError = await captureError(() =>
+            authorization.save(ownerIdentity, unclosedBatch(owner)));
+
+        const router = createRouterWithFailingSave(engineError);
+        const declaration =
+            `let workspace: ${Workspace.Type} = { owner: me, identifier: "workspace-1" }\n` +
+            `let application: ${Application.Type} = { workspace: workspace, name: "application-1" }\n`;
+
+        const error = await captureError(() => (router as any).write(requestUser, declaration));
+
+        expect(error).toBeInstanceOf(Invalid);
+        expect(error.message).toContain("were not found in storage and were not included in the request");
+    });
+
+    it("still translates the authorization-rule shape fixed by issue #175", async () => {
+        const router = createRouterWithFailingSave(
+            new Error("The fact ErrorStatus.Workspace:abc123 is not defined."));
+
+        const error = await captureError(() =>
+            (router as any).save(requestUser, graphSourceOf([])));
+
+        expect(error).toBeInstanceOf(Invalid);
+        expect(error.message).toContain("ErrorStatus.Workspace:abc123 is required to authorize this save");
+    });
+});
+
+// Issue #182 findings 3 and 4, exercised over real HTTP so the assertions are
+// on the status line a client actually receives.
+describe("HTTP status mapping", () => {
+    let server: Server;
+    let baseUrl: string;
+
+    async function listen(app: express.Express) {
+        server = app.listen(0);
+        await new Promise<void>(resolve => server.once("listening", () => resolve()));
+        const port = (server.address() as AddressInfo).port;
+        baseUrl = `http://127.0.0.1:${port}`;
+    }
+
+    afterEach(async () => {
+        if (server) {
+            await new Promise<void>(resolve => server.close(() => resolve()));
+        }
+    });
+
+    describe("with no body parser registered", () => {
+        beforeEach(async () => {
+            const { router } = await createHarness();
+            const app = express();
+            app.use(router.handler);
+            await listen(app);
+        });
+
+        // Each of these parses the body synchronously in the handler. Express
+        // used to hand the throw to its default error handler, reporting the
+        // client's malformed request as a 500.
+        it.each([
+            ["/write", "text/plain"],
+            ["/read", "text/plain"],
+            ["/feeds", "text/plain"],
+            ["/load", "application/json"]
+        ])("answers 400 for %s when the body cannot be read", async (path, contentType) => {
+            const response = await fetch(`${baseUrl}${path}`, {
+                method: "POST",
+                headers: { "Content-Type": contentType },
+                body: contentType === "application/json" ? "{}" : "anything"
+            });
+
+            expect(response.status).toBe(400);
+        });
+    });
+
+    it("answers 500 without echoing the internal error message", async () => {
+        const store = new MemoryStore();
+        const factManager = new FactManager(
+            new PassThroughFork(store), new ObservableSource(store), store, new NetworkNoOp(), []);
+        const secret = "connection to postgres://internal-host:5432 refused";
+        const failingAuthorization = {
+            load: () => Promise.reject(new Error(secret))
+        } as unknown as Authorization & SubscriptionAuthorizer;
+        const router = new HttpRouter(factManager, failingAuthorization, new FeedCache(), "*");
+
+        const app = express();
+        app.use(express.json());
+        app.use(router.handler);
+        await listen(app);
+
+        const response = await fetch(`${baseUrl}/load`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ references: [] })
+        });
+        const body = await response.text();
+
+        expect(response.status).toBe(500);
+        expect(body).toBe("Internal server error");
+        expect(body).not.toContain("internal-host");
+    });
+
+    it("answers 404 with a distinguishable body for a feed route miss", async () => {
+        const { router } = await createHarness();
+        const app = express();
+        app.use(router.handler);
+        await listen(app);
+
+        // A hash the feed cache has never seen resolves to FeedNotFound, which
+        // is a different 404 from the route miss below.
+        const cacheMiss = await fetch(`${baseUrl}/feeds/unknownhash`);
+        expect(cacheMiss.status).toBe(404);
+        expect(await cacheMiss.text()).toBe("feed_not_found");
+    });
+});

--- a/test/http/errorStatusMappingSpec.ts
+++ b/test/http/errorStatusMappingSpec.ts
@@ -224,6 +224,19 @@ describe("HTTP status mapping", () => {
 
             expect(response.status).toBe(400);
         });
+
+        // The text/plain-only routes name the parser the caller is missing,
+        // rather than falling back to parseString's generic content-type
+        // message.
+        it.each(["/write", "/read"])("names express.text() in the 400 body for %s", async (path) => {
+            const response = await fetch(`${baseUrl}${path}`, {
+                method: "POST",
+                headers: { "Content-Type": "text/plain" },
+                body: "anything"
+            });
+
+            expect(await response.text()).toContain("express.text()");
+        });
     });
 
     it("answers 500 without echoing the internal error message", async () => {

--- a/test/http/errorStatusMappingSpec.ts
+++ b/test/http/errorStatusMappingSpec.ts
@@ -258,6 +258,34 @@ describe("HTTP status mapping", () => {
             expect(await response.text()).toContain("No Content-Type header was received");
         });
 
+        // The echoed Content-Type is client-supplied, so it must not be able to
+        // carry markup into the body.
+        it("neutralizes markup in the echoed Content-Type", async () => {
+            const response = await fetch(`${baseUrl}/write`, {
+                method: "POST",
+                headers: { "Content-Type": "text/plain<script>alert(1)</script>" },
+                body: "anything"
+            });
+            const body = await response.text();
+
+            expect(response.status).toBe(400);
+            expect(body).not.toContain("<script>");
+            expect(body).toContain("&lt;script&gt;");
+        });
+
+        it("caps the length of the echoed Content-Type", async () => {
+            const response = await fetch(`${baseUrl}/write`, {
+                method: "POST",
+                headers: { "Content-Type": `text/plain;padding=${"x".repeat(500)}` },
+                body: "anything"
+            });
+            const body = await response.text();
+
+            expect(response.status).toBe(400);
+            expect(body).toContain("…");
+            expect(body.length).toBeLessThan(300);
+        });
+
         it("marks error responses nosniff", async () => {
             const response = await fetch(`${baseUrl}/write`, {
                 method: "POST",

--- a/test/http/errorStatusMappingSpec.ts
+++ b/test/http/errorStatusMappingSpec.ts
@@ -237,6 +237,37 @@ describe("HTTP status mapping", () => {
 
             expect(await response.text()).toContain("express.text()");
         });
+
+        // Saying what arrived tells the caller which end is misconfigured.
+        it("names the Content-Type that was received", async () => {
+            const response = await fetch(`${baseUrl}/write`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: "{}"
+            });
+
+            expect(await response.text()).toContain("Received Content-Type: application/json");
+        });
+
+        it("says so when no Content-Type was received", async () => {
+            const response = await fetch(`${baseUrl}/write`, {
+                method: "POST",
+                body: new Blob(["anything"])
+            });
+
+            expect(await response.text()).toContain("No Content-Type header was received");
+        });
+
+        it("marks error responses nosniff", async () => {
+            const response = await fetch(`${baseUrl}/write`, {
+                method: "POST",
+                headers: { "Content-Type": "text/plain" },
+                body: "anything"
+            });
+
+            expect(response.status).toBe(400);
+            expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+        });
     });
 
     it("answers 500 without echoing the internal error message", async () => {
@@ -264,6 +295,9 @@ describe("HTTP status mapping", () => {
         expect(response.status).toBe(500);
         expect(body).toBe("Internal server error");
         expect(body).not.toContain("internal-host");
+        // A plain-text body labelled text/html invites a browser to render it.
+        expect(response.headers.get("content-type")).toContain("text/plain");
+        expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     });
 
     it("answers 404 with a distinguishable body for a feed route miss", async () => {


### PR DESCRIPTION
Fixes #182. Supersedes #158 — see the note at the end.

`handleError` classifies errors by an allow-list, so several client-caused failures reached callers as 500s. This addresses all six findings; finding 5 is closed by the `jinaga@6.11.3` bump described below.

## Findings 1 and 2 — missing predecessors

`toSaveAuthorizationError` matched only the message that authorization-*rule* evaluation produces (`The fact <type>:<hash> is not defined.`, the shape #175 fixed). jinaga's `AuthorizationEngine.authorizeFacts` reports the same underlying condition from its topological sort, which never matched that regex and fell through to a bare 500.

That path is now an `instanceof PredecessorNotResolvedError` check — see finding 5.

`write()` called `this.authorization.save(...)` with no try/catch, so `/write` translated neither shape. It now wraps the call the same way `save()` does.

Note on reachability: the declaration grammar `/write` accepts cannot express a dangling predecessor, so the gap is not reproducible through that route today — the fix is for consistency, since `/write` makes the same authorization call and the routes should not drift apart again.

## Finding 3 — malformed request bodies

This turned out to be broader than the issue describes. Besides the two hardcoded `res.status(500)` calls on `/read` and `/write`, `parseString` and jinaga's message parsers throw **synchronously** from inside the Express handler, so Express handed the throw to its default error handler and answered 500 without `handleError` ever running. That affected `/load` and `/feeds` too.

Parsing now goes through a small `parseRequestInput` helper that classifies any parse failure as `Invalid`, which `handleError` renders as a 400. Routing through `handleError` also picks up the `Trace.warn` and the `next()` call the two hardcoded branches skipped.

The messages also now name the Content-Type that arrived — or say that none did — so the caller can tell which end is misconfigured instead of guessing.

## Finding 4 — unclassified 500s

The generic branch sent `error.message` to the caller, which could name an internal host. It now sends `Internal server error`; the detail stays in the `Trace.error` call that was already there.

Three supporting fixes, two from #158 and one from CodeQL's review of this branch:

- `outputReadResults` sent its 500 without calling `res.type`, and `res.send` of a string with no type set makes Express infer `text/html` — the one error path that was labelling a plain-text body as markup.
- `handleError` now sets `X-Content-Type-Options: nosniff`. The repo sets no security headers today.
- Error bodies quote client-supplied text — a Content-Type header, a fact type named in a parse failure — so `&`, `<`, and `>` are escaped at the single point where every error body is written. The responses are `text/plain` and `nosniff`, but that guarantee is itself a header; escaping at the write point does not depend on one. Quotes are left alone: they only matter inside a tag, which escaping `<` already prevents, and these messages quote identifiers routinely. The echoed Content-Type is also length-capped so the body cannot grow with whatever the caller sends.

## Finding 6 — feed 404 bodies

The route-miss branch answered `sendStatus(404)` with an empty body while a cache miss answered `feed_not_found`. The route miss now sends `not_found`, so a client can always read the body to tell "wrong URL" from "re-subscribe via POST /feeds". This is a body-content change on `GET /feeds/:hash`; the status is unchanged.

## Finding 5 — closed by jinaga 6.11.3

`jinaga@6.11.3` shipped the typed errors of jinaga/jinaga.js#234. `AuthorizationEngine.authorizeFacts` now throws `PredecessorNotResolvedError`, carrying `missingPredecessors` and `unresolvedFacts` as `FactReference[]`, so this repo `instanceof`-checks it instead of regexing prose. Dependency moved to `^6.11.3`; the export diff against 6.11.1 is purely additive, nothing removed.

**This is a required part of the fix, not an improvement.** 6.11.3 also reworded that message, and `package.json` declared `^6.11.1` — a caret range that already resolves to 6.11.3. Without this commit, finding 1's fix would have shipped inert for anyone installing fresh. The drift these tests were written to catch arrived one release after they were written, and they caught it: three of them failed on the bump before the code was changed.

The structured fields also make the response better than the pattern ever could. The regex could only name the successors that failed to sort; the 400 now names the predecessor that is actually missing — the fact the caller has to go find.

One prose pattern remains, `FACT_NOT_DEFINED_PATTERN`, for specification-runner's `The fact X:Y is not defined.` — still a bare `Error` in 6.11.3.

Worth noting for downstream: 6.11.3's other half fixes the client-side message loss also tracked in jinaga.js#234. `WebClient` previously threw `new Error(statusMessage)`, discarding the response body and keeping only the generic HTTP reason phrase. It now throws `HttpError`/`ForbiddenError` carrying `reason`, `statusCode`, and `body`, and `responseReason` prefers a plain-string body — which is exactly what this router sends. The 4xx bodies improved here will now actually reach callers, which issue #182 noted they previously did not.

## Tests

New `test/http/errorStatusMappingSpec.ts`, 17 cases, no new dependencies:

- the unresolved-predecessor error from the real engine, asserted as the typed error with its structured fields, and translated at `/save` to a 400 that names the missing predecessor
- the same translation at `/write`, replaying the error captured from the real engine
- the #175 prose shape still translated
- 400 rather than 500 for unreadable bodies on `/write`, `/read`, `/feeds`, and `/load`, driven over real HTTP against a live express app
- the 400 body names the parser the caller is missing and the Content-Type that arrived, in both the present and absent cases
- a `Content-Type` carrying `<script>` comes back escaped, and an overlong one comes back truncated
- 500 whose body is `Internal server error`, typed `text/plain`, marked `nosniff`, and not containing the underlying message
- `feed_not_found` on a cache miss

7 of the first 10 failed against the pre-fix router; the ones that passed were the deliberate baselines. Full suite: 19 suites pass, `npm run build` clean.

One gap worth naming: the `res.type` fix on `outputReadResults` is covered by type-check and the existing read/CSV specs, not by a dedicated test — provoking a mid-stream formatter failure before headers are sent isn't reliably reachable from the outside.

## Relationship to #158

#158 ("Improve error handling") targets the same area but has been conflicted since October and predates both #168's `FeedNotFound` and #175's `toSaveAuthorizationError`. Its core change — try/catch so synchronous parse throws reach `handleError` — is the same fix this PR makes via `parseRequestInput`, so the branch is largely superseded. The three parts worth keeping are folded in above (the `res.type` fix, `nosniff`, and naming the received Content-Type).

Deliberately not carried over: its multi-paragraph error bodies, and its logging of a 100-character preview of the request body — request bodies here are facts, which can carry personal data, and that path is client-triggerable.

Two things from #158 remain open and are **not** in this PR:

1. Its stated goal, "assume text/plain when content type is omitted," isn't achieved by its change. It reorders `express.text()` ahead of `express.json()`, but both parsers gate on `type-is`, which returns `false` when the Content-Type header is absent — so with no Content-Type neither parser runs, regardless of order. Doing this for real needs an explicit predicate such as `express.text({ type: req => !req.headers['content-type'] })`. That's a leniency decision about the replicator binary, not the router library.
2. body-parser's own failures never reach `handleError` — malformed JSON throws in middleware before the router runs, so Express's default handler answers with an HTML page. The statuses are already right (400/413); it's the body format that's off. A trimmed version of #158's global handler in `replicator/index.ts` would fix it, as its own change.